### PR TITLE
Merging new AMC certs functionality theme-side code

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -5,6 +5,7 @@
   from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
   from contentstore.context_processors import doc_url
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <div class="wrapper-header wrapper" id="view-top">
   <header class="primary" role="banner">
@@ -17,6 +18,7 @@
       % if context_course:
       <%
             course_key = context_course.id
+            current_organization = request.user.organizations.first()
             index_url = reverse('contentstore.views.course_handler', kwargs={'course_key_string': unicode(course_key)})
             course_team_url = reverse('contentstore.views.course_team_handler', kwargs={'course_key_string': unicode(course_key)})
             assets_url = reverse('contentstore.views.assets_handler', kwargs={'course_key_string': unicode(course_key)})
@@ -30,7 +32,7 @@
             advanced_settings_url = reverse('contentstore.views.advanced_settings_handler', kwargs={'course_key_string': unicode(course_key)})
             tabs_url = reverse('contentstore.views.tabs_handler', kwargs={'course_key_string': unicode(course_key)})
             certificates_url = ''
-            if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
+            if configuration_helpers.get_value_for_org(current_organization.name, "CERTIFICATES_HTML_VIEW", False) and context_course.cert_html_view_enabled:
                 certificates_url = reverse('contentstore.views.certificates.certificates_list_handler', kwargs={'course_key_string': unicode(course_key)})
       %>
       <h2 class="info-course">

--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -1,0 +1,2 @@
+@import "certificates/certificates-base";
+@import "certificates/certificate-template-01";

--- a/lms/static/sass/certificates/_certificate-template-01.scss
+++ b/lms/static/sass/certificates/_certificate-template-01.scss
@@ -1,0 +1,320 @@
+.a--accomplishment-design-01 {
+  color: $base-text-color;
+
+  &__body-wrapper {
+    @include linear-gradient(to right, $brand-primary-color, darken($brand-primary-color, 15%));
+    @include display(flex);
+    @include flex-direction(column);
+  }
+
+  &__body {
+    @include display(flex);
+    @include flex-grow(1);
+    padding: 7.5em 6em 3em;
+
+    @media (max-width: 900px) {
+      @include flex-wrap(wrap);
+    }
+
+    @media screen {
+      padding: 7.5em 6em;
+    }
+  }
+
+  &__platform-info {
+    @include display(flex);
+    @include flex-direction(column);
+    @include justify-content(space-between);
+    width: 30%;
+    padding: 5em;
+    position: relative;
+    z-index: 1;
+    background-color: #F8F8F8;
+    box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+
+    @media (max-width: 900px) {
+      width: 100%;
+    }
+
+    &__main {
+      text-align: center;
+      margin: 5em;
+
+      .organisation-logo {
+        max-width: 100%;
+        display: block;
+        height: auto;
+        margin: 0 auto 6em;
+      }
+
+      .platform-name {
+        font-size: 4em;
+        @include primary-font;
+        margin: 0 0 1.5em;
+      }
+
+      p {
+        font-size: 3em;
+        @include primary-font-light;
+        margin: 1em;
+      }
+    }
+
+    &__signatures {
+      @include display(flex);
+      @include flex-direction(column);
+
+      .signature-container {
+        margin: 5em;
+        text-align: center;
+
+        .signee-signature {
+          display: block;
+          max-width: 100%;
+          max-height: 15em;
+          height: auto;
+          margin: 0 auto 0.5em;
+        }
+
+        .signee-name {
+          display: block;
+          font-size: 3.5em;
+          @include primary-font;
+          line-height: 150%;
+        }
+
+        .signee-title {
+          display: block;
+          font-size: 2.5em;
+          @include primary-font;
+          text-transform: uppercase;
+          color: lighten($base-text-color, 15%);
+        }
+
+        .signee-organisation {
+          display: block;
+          font-size: 2.5em;
+          @include primary-font;
+          color: lighten($base-text-color, 15%);
+        }
+      }
+    }
+  }
+
+  &__main {
+    display: flex;
+    align-items: center;
+    width: 70%;
+    padding: 10em;
+    position: relative;
+    z-index: 2;
+    background-color: #fff;
+    box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+
+    @media (max-width: 900px) {
+      width: 100%;
+    }
+
+    &__content {
+
+      .main-header {
+        display: flex;
+        align-items: center;
+
+        .accomplishment-type-symbol {
+          width: 15em;
+          margin-right: 5em;
+
+          img {
+            width: 100%;
+            height: auto;
+          }
+        }
+
+        .course-info {
+          color: $brand-primary-color;
+          @include primary-font-light;
+          font-size: 4.5em;
+          line-height: 150%;
+        }
+      }
+
+      .vertical-divider-bar {
+        display: block;
+        width: 90em;
+        max-width: 100%;
+        height: 1em;
+        background-color: $brand-primary-color;
+        margin: 10em 0;
+      }
+
+      p {
+        font-size: 4em;
+        @include primary-font-light;
+      }
+
+      .student-name {
+        @include primary-font;
+        color: $brand-primary-color;
+        font-size: 18em;
+      }
+
+      .course-name-main {
+        color: $brand-primary-color;
+        font-size: 6em;
+        @include primary-font-light;
+      }
+    }
+  }
+}
+
+.a--accomplishment-design-01__certificate-info-print-only {
+  overflow: visible;
+
+  @media screen {
+    display: none;
+  }
+}
+
+
+.a--accomplishment-design-01__body-wrapper.portrait {
+
+  .a--accomplishment-design-01 {
+
+    &__body {
+      @include flex-direction(column);
+    }
+
+    &__platform-info {
+      order: 2;
+      @include flex-direction(row);
+      width: 100%;
+
+      &__main {
+        width: 30%;
+      }
+
+      &__signatures {
+        width: 69%;
+        @include flex-direction(row);
+        @include align-items(center);
+      }
+    }
+
+    &__main {
+      order: 1;
+      @include flex-grow(1);
+      width: 100%;
+    }
+  }
+}
+
+// Part responsible for proper print output
+
+@media print {
+  .a--accomplishment-design-01 {
+
+    &__body {
+      width: 100%;
+      padding: 1.5cm 1cm 0.7cm;
+    }
+
+    &__platform-info {
+      width: 30%;
+      background-color: #F8F8F8;
+
+      &__main {
+        margin: 0.2cm 0.5cm 0.5cm;
+
+        .organisation-logo {
+          margin-bottom: 0.6cm;
+        }
+
+        .platform-name {
+          font-size: 12pt;
+          margin: 0 0 0.15cm;
+        }
+
+        p {
+          font-size: 8pt;
+          margin: 0.4cm;
+        }
+      }
+
+      &__signatures {
+
+        .signature-container {
+          margin: 0.2cm;
+
+          .signee-signature {
+            margin: 0 auto;
+          }
+
+          .signee-name {
+            font-size: 10pt;
+          }
+
+          .signee-title {
+            font-size: 8pt;
+          }
+
+          .signee-organisation {
+            font-size: 8pt;
+          }
+        }
+      }
+    }
+
+    &__main {
+      width: 69%;
+      padding: 1cm;
+      background-color: #fff;
+
+      &__content {
+
+        .main-header {
+
+          .accomplishment-type-symbol {
+            width: 1.5cm;
+            margin-right: 0.5cm;
+          }
+
+          .course-info {
+            font-size: 14pt;
+          }
+        }
+
+        .vertical-divider-bar {
+          width: 9cm;
+          height: 0.1cm;
+          margin: 1cm 0;
+        }
+
+        p {
+          font-size: 12pt;
+        }
+
+        .student-name {
+          font-size: 42pt;
+        }
+
+        .course-name-main {
+          font-size: 18pt;
+        }
+      }
+    }
+
+    &__certificate-info-print-only {
+      @include display(flex);
+      @include align-items(center);
+      margin-bottom: 0.7cm;
+      font-size: 0.25cm;
+      padding: 0 1.1cm;
+      color: #fff;
+
+      .info-right {
+        margin-left: auto;
+      }
+    }
+  }
+}

--- a/lms/static/sass/certificates/_certificates-base.scss
+++ b/lms/static/sass/certificates/_certificates-base.scss
@@ -1,0 +1,115 @@
+.a--accomplishment {
+
+  &--header-logo {
+    width: auto;
+  }
+
+  &--wrapper {
+    margin-bottom: 2.5rem;
+    width: 100%;
+    font-size: 4px;
+    background-color: #f0f0f0;
+
+    @media (min-width: 900px) and (max-width: 1200px) {
+      font-size: 3px;
+    }
+  }
+  &__body-wrapper {
+    width: 100%;
+    position: relative;
+    margin: 0 auto;
+
+    @media screen {
+      position: relative;
+      top: -3rem;
+    }
+
+    @media (min-width: 900px) {
+
+      &.landscape {
+
+        &.paper-eu-a4 {
+          width: 297em;
+          height: 210em;
+        }
+
+        &.paper-us-letter {
+          width: 279.4em;
+          height: 215.9em;
+        }
+      }
+
+      &.portrait {
+
+        &.paper-eu-a4 {
+          width: 210em;
+          height: 297em;
+        }
+
+        &.paper-us-letter {
+          width: 215.9em;
+          height: 279.4em;
+        }
+      }
+    }
+  }
+
+  &__body {
+
+  }
+}
+
+@media print {
+
+  .layout-accomplishment {
+    margin: 0 !important;
+    padding: 0;
+  }
+
+  .a--accomplishment {
+
+    &--wrapper {
+      margin: 0;
+      padding: 0;
+
+      .bs-container {
+        padding: 0;
+      }
+    }
+    &__body-wrapper {
+
+      @media (min-width: 900px) {
+
+        &.landscape {
+
+          &.paper-eu-a4 {
+            width: 29.7cm;
+            height: 21cm;
+          }
+
+          &.paper-us-letter {
+            width: 27.94cm;
+            height: 21.59cm;
+          }
+        }
+
+        &.portrait {
+
+          &.paper-eu-a4 {
+            width: 29.7cm;
+            height: 21cm;
+          }
+
+          &.paper-us-letter {
+            width: 27.94cm;
+            height: 21.59cm;
+          }
+        }
+      }
+    }
+
+    &__body {
+
+    }
+  }
+}

--- a/lms/templates/certificates/_about-accomplishments.html
+++ b/lms/templates/certificates/_about-accomplishments.html
@@ -1,0 +1,8 @@
+<%namespace file='/theme-variables.html' import="get_certificates_settings" />
+<section class="about-item about-accomplishments">
+    <h2 class="about-title hd-4">${accomplishment_copy_about}</h2>
+
+    <div class="about-copy copy copy-meta">
+        <p>${get_certificates_settings()['footer_about_accomplishments_text']}</p>
+    </div>
+</section>

--- a/lms/templates/certificates/_about-edx.html
+++ b/lms/templates/certificates/_about-edx.html
@@ -1,0 +1,12 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%namespace file='/theme-variables.html' import="get_certificates_settings" />
+<section class="about-item about-edx">
+    <h2 class="about-edx-title hd-4">${company_about_title}</h2>
+
+    <div class="about-edx-copy copy copy-meta">
+        <p>${get_certificates_settings()['footer_about_platform_text']}</p>
+        % if (get_certificates_settings()['footer_about_platform_url'] != "#") and (get_certificates_settings()['footer_about_platform_url'] != ""):
+          <a class="action" href="${get_certificates_settings()['footer_about_platform_url']}">${company_about_urltext}</a>
+        % endif
+    </div>
+</section>

--- a/lms/templates/certificates/_accomplishment-banner.html
+++ b/lms/templates/certificates/_accomplishment-banner.html
@@ -1,0 +1,93 @@
+<%!
+from django.utils.translation import ugettext as _
+from django.template.defaultfilters import escapejs
+%>
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/theme-variables.html' import="get_certificates_settings" />
+<%block name="js_extra">
+  <%static:js group='certificates_wv'/>
+  <script type="text/javascript">
+      $(document).ready(function() {
+          FaceBook.init({"facebook_app_id": '${facebook_app_id}'});
+          $.ajaxSetup({
+              headers: {
+                  'X-CSRFToken': $.cookie('csrftoken')
+              },
+              dataType: 'json'
+          });
+          $(".action-linkedin-profile").click(function() {
+              var data = {
+                  user_id: '${accomplishment_user_id}',
+                  course_id: $(this).data('course-id'),
+                  enrollment_mode: $(this).data('certificate-mode'),
+                  certificate_id: '${certificate_id_number}',
+                  certificate_url: window.location.href,
+                  social_network: 'LinkedIn'
+              };
+              Logger.log('edx.certificate.shared', data);
+              window.open('${linked_in_url}');
+          });
+      });
+
+      function popupWindow(url, title, width, height) {
+          // popup a window at center of the screen.
+          var left = (screen.width/2)-(width/2);
+          var top = (screen.height/2)-(height/2);
+          return window.open(url, title, 'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width='+width+', height='+height+', top='+top+', left='+left);
+      }
+  </script>
+</%block>
+<div id="fb-root"></div>
+<div class="wrapper-banner wrapper-banner-user">
+    <section class="banner banner-user">
+        <div class="message message-block message-notice">
+            <h2 class="message-title hd-5 emphasized">${accomplishment_banner_opening | h}</h2>
+            <div class="wrapper-copy-and-actions">
+                <p class="message-copy copy copy-base emphasized">${get_certificates_settings()['header_text']}</p>
+                <div class="message-actions">
+                    <h3 class="sr-only">${_("Print or share your certificate:")}</h3>
+                    % if facebook_share_enabled:
+                      <button class="action action-share-facebook btn-inverse btn-small icon-only" id="action-share-facebook"
+                         onclick="FaceBook.share({
+                          share_text: '${facebook_share_text | escapejs}',
+                          share_link: '${share_url}',
+                          picture_link: '${full_course_image_url}',
+                          description: '${_('Click the link to see my certificate.') | escapejs}'
+                          });">
+                          <span class="icon fa fa-facebook-official" aria-hidden="true"></span>
+                          <span class="action-label">${_("Post on Facebook")}</span>
+                      </button>
+                    %endif
+                    % if twitter_share_enabled:
+                      <button data-tooltip="${_('Share on Twitter')}"
+                        class="action action-share-twitter btn-inverse btn-small icon-only"
+                        title="${_('Share on Twitter')}"
+                        onclick="popupWindow('${twitter_url}', 'tweetWindow', 640, 480); return false;">
+                          <span class="icon fa fa-twitter" aria-hidden="true"></span>
+                          <span class="action-label">${_("Tweet this Accomplishment. Pop up window.")}</span>
+                      </button>
+                    %endif
+
+                    %if linked_in_url:
+                    <button class="action action-linkedin-profile btn-inverse btn-small icon-only" id="action-share-linkedin" title="${_('Add to LinkedIn Profile')}" data-course-id="${course_id}" data-certificate-mode="${course_mode}">
+                        <span class="icon fa fa-linkedin" aria-hidden="true"></span>
+                        <span class="action-label">${_("Add to LinkedIn Profile")}</span>
+                    </button>
+                    %endif
+
+                    %if badge:
+                    <button class="action action-share-mozillaopenbadges btn btn-overlay btn-small">
+                        <img class="icon icon-mozillaopenbadges" src="/static/certificates/images/ico-mozillaopenbadges.png" alt="Mozilla Open Badges Backpack">
+                        ${_("Add to Mozilla Backpack")}
+                    </button>
+                    %endif
+
+                    <button class="action action-print btn-inverse btn-small" id="action-print-view">
+                        <span class="icon fa fa-print" aria-hidden="true"></span>
+                        ${_("Print Certificate")}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/lms/templates/certificates/_accomplishment-footer.html
+++ b/lms/templates/certificates/_accomplishment-footer.html
@@ -1,0 +1,25 @@
+<%namespace file='/theme-variables.html' import="get_certificates_settings" />
+
+<div class="wrapper-footer">
+
+    <footer class="footer-app" role="contentinfo" id="company-info">
+        <div class="footer-app-copyright">
+            <p class="copy copy-micro">${get_certificates_settings()['footer_copyright_text']}</p>
+        </div>
+        <nav class="footer-app-nav">
+            <ul class="list list-legal">
+                % if (get_certificates_settings()['footer_tos_url'] != "#") and (get_certificates_settings()['footer_tos_url'] != ""):
+                  <li class="nav-item">
+                      <a class="action btn btn-small btn-link" href="${get_certificates_settings()['footer_tos_url']}">${company_tos_urltext}</a>
+                  </li>
+                % endif
+                % if (get_certificates_settings()['footer_privacy_url'] != "#") and (get_certificates_settings()['footer_privacy_url'] != ""):
+                  <li class="nav-item">
+                      <a class="action btn btn-small btn-link" href="${get_certificates_settings()['footer_privacy_url']}">${company_privacy_urltext}</a>
+                  </li>
+                % endif
+            </ul>
+        </nav>
+    </footer>
+
+</div>

--- a/lms/templates/certificates/_accomplishment-header.html
+++ b/lms/templates/certificates/_accomplishment-header.html
@@ -1,0 +1,16 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/theme-variables.html' import="get_certificates_settings" />
+
+<div class="wrapper-header">
+
+    <header class="header-app" role="banner">
+        <h1 class="header-app-title">
+            <a class="logo" href="${logo_url}" style="width: auto;">
+                <img class="a--accomplishment--header-logo" style="width: ${get_certificates_settings()['header_logo_width']}; height: auto;" src="${get_certificates_settings()['header_logo']}" alt="${get_certificates_settings()['platform_name']}" />
+            </a>
+            <span class="sr-only">${logo_subtitle}</span>
+        </h1>
+    </header>
+
+</div>

--- a/lms/templates/certificates/_accomplishment-introduction.html
+++ b/lms/templates/certificates/_accomplishment-introduction.html
@@ -1,0 +1,7 @@
+<div class="wrapper-introduction">
+    <section class="introduction">
+        <h2 class="introduction-copy hd-2 emphasized">
+            ${document_banner}
+        </h2>
+    </section>
+</div>

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -1,0 +1,71 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/theme-variables.html' import="get_certificates_settings" />
+<%
+course_mode_class = course_mode if course_mode else ''
+%>
+
+<main class="a--accomplishment--wrapper a--accomplishment--main">
+  <div class="bs-container a--container">
+    <div class="a--accomplishment__body-wrapper a--accomplishment-design-01__body-wrapper ${get_certificates_settings()['paper_orientation']} paper-eu-a4">
+      <div class="a--accomplishment__body a--accomplishment-design-01__body">
+        <div class="a--accomplishment-design-01__platform-info">
+          <div class="a--accomplishment-design-01__platform-info__main">
+            <img class="organisation-logo" src="${get_certificates_settings()['cert_logo']}" role="presentation" style="width: ${get_certificates_settings()['logo_width']};" />
+            <span class="platform-name">${get_certificates_settings()['platform_name']}</span>
+            <p>
+              ${get_certificates_settings()['short_platform_description']}
+            </p>
+          </div>
+          <div class="a--accomplishment-design-01__platform-info__signatures">
+            % if certificate_data:
+                % for signatory in certificate_data.get('signatories', []):
+                  <div class="signature-container">
+                    <img class="signee-signature" src="${static.url(signatory['signature_image_path'])}" alt="Signature | ${signatory['name']}" />
+                    <span class="signee-name">${signatory['name']}</span>
+                    <span class="signee-title">${signatory['title']}</span>
+                    <span class="signee-organisation">${signatory['organization']}</span>
+                  </div>
+                % endfor
+            % endif
+          </div>
+        </div>
+        <div class="a--accomplishment-design-01__main">
+          <div class="a--accomplishment-design-01__main__content">
+            <div class="main-header">
+              <span class="accomplishment-type-symbol">
+                  <img class="src" src="/static/certificates/images/ico-${course_mode_class}.png" alt="">
+              </span>
+              <h3 class="course-info">
+                ${document_title}
+              </h3>
+            </div>
+            <span class="vertical-divider-bar"></span>
+            <p>
+              ${get_certificates_settings()['we_hereby_text']}
+            </p>
+            <h1 class="student-name">${accomplishment_copy_name | h}</h1>
+            <p>
+              ${get_certificates_settings()['successfully_completed_text']}
+            </p>
+            <h2 class="course-name-main"><span class="course-organization">${accomplishment_copy_course_org}</span> | <span class="course-number">${course_number}</span>: <span class="course-name">${accomplishment_copy_course_name}</span></h2>
+            <p>
+              ${get_certificates_settings()['optional_cert_text']}
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="a--accomplishment-design-01__certificate-info-print-only">
+        <div class="info-left">
+          Certificate ID number: <b>${certificate_id_number}</b>
+        </div>
+        <div class="info-right">
+          <b>${certificate_date_issued}</b>
+        </div>
+        <div>
+          Verify the authenticity of this certificate at <a href="https://${request.site}/certificates/user/${accomplishment_user_id}/course/${course_id}">https://${request.site}/certificates/user/${accomplishment_user_id}/course/${course_id}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/lms/templates/certificates/accomplishment-base.html
+++ b/lms/templates/certificates/accomplishment-base.html
@@ -1,0 +1,59 @@
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/theme-variables.html' import="get_global_settings" />
+<%! from django.utils.translation import ugettext as _ %>
+<%! from openedx.core.djangoapps.site_configuration.helpers import get_value %>
+
+<%
+# set doc language direction
+from django.utils.translation import get_language_bidi
+dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
+course_mode_class = course_mode if course_mode else ''
+%>
+
+<%
+style_overrides_file = get_value('css_overrides_file')
+if style_overrides_file:
+  style_overrides_file = 'customer_themes/' + style_overrides_file
+endif
+%>
+
+<!DOCTYPE html>
+<html class="certs-page no-js" lang="en">
+<head dir="${dir_rtl}">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>${document_title}</title>
+
+    <%static:css group='style-certificates'/>
+
+    % if style_overrides_file:
+      <link rel="stylesheet" type="text/css" href="${static.url(style_overrides_file)}" />
+    % else:
+      <link rel="stylesheet" type="text/css" href="${static.url('css/main.css')}">
+    % endif
+    <link href="${get_global_settings()['fonts_url']}" rel="stylesheet" />
+</head>
+
+<body class="layout-accomplishment view-valid-accomplishment ${dir_rtl} certificate certificate-${course_mode_class}" data-view="valid-accomplishment">
+
+    <div class="wrapper-view" dir="${dir_rtl}">
+
+        <%include file="_accomplishment-header.html" />
+
+        <hr class="divider sr-only">
+
+        ${self.body()}
+
+        <hr class="divider sr-only">
+
+        <%include file="_accomplishment-footer.html" />
+    </div>
+
+    <%include file="/certificates/_assets-secondary.html" />
+    %if badge:
+        <%include file="/certificates/_badges-modal.html" />
+    %endif
+</body>
+</html>

--- a/lms/templates/certificates/invalid.html
+++ b/lms/templates/certificates/invalid.html
@@ -1,0 +1,17 @@
+<%inherit file="accomplishment-base.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<div class="wrapper-content status status-invalid">
+    <div class="wrapper-content-grid">
+        <main class="content content-main">
+            <section class="">
+                <h2 class="title">${_("Cannot Find Certificate")}</h2>
+                <div class="copy">
+                    <p>${_("We cannot find a certificate with this URL or ID number. If you are trying to validate a certificate, make sure that the URL or ID number is correct. If you are sure that the URL or ID number is correct, contact support.")}</p>
+                </div>
+            </section>
+        </main>
+        <aside role="complementary" class="content-secondary about" aria-label="About ${platform_name} Certificates">
+        </aside>
+    </div>
+</div>

--- a/lms/templates/certificates/server-error.html
+++ b/lms/templates/certificates/server-error.html
@@ -1,0 +1,24 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="/main.html" />
+
+<%block name="pagetitle">${_("Invalid Certificate Configuration.")}</%block>
+
+<section class="outside-app">
+    <h1>
+        ${_(u"There is a problem with this certificate.")}
+    </h1>
+
+    <div>
+        <p>
+            ${_("To resolve the problem, your partner manager should verify that the following information is correct.")}
+        </p>
+        <ul>
+            <li>${_("The institution&#39;s logo.")}</li>
+            <li>${_("The institution that is linked to the course.")}</li>
+            <li>${_("The course information in the Course Administration tool.")}</li>
+        </ul>
+        <br/>
+        <p>${_("If all of the information is correct and the problem persists, contact technical support.")}</p>
+    </div>
+
+</section>

--- a/lms/templates/certificates/valid.html
+++ b/lms/templates/certificates/valid.html
@@ -1,0 +1,15 @@
+<%inherit file="accomplishment-base.html" />
+<%! from django.utils.translation import ugettext as _ %>
+
+% if user.is_authenticated() and user.id == int(accomplishment_user_id):
+<%include file="_accomplishment-banner.html" />
+% endif
+<%include file="_accomplishment-introduction.html" />
+
+<%include file="_accomplishment-rendering.html" />
+<div class="wrapper-about">
+    <aside role="complementary" class="about" aria-label="About edX Certificates">
+        <%include file="_about-edx.html" />
+        <%include file="_about-accomplishments.html" />
+    </aside>
+</div>

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -24,14 +24,20 @@
             <%static:include path="student_account/${template_name}.underscore" />
         </script>
     % endfor
-    % if get_global_settings()['enable_registration_link_on_login']:
+    % if get_global_settings().get('sso_disable_login_fields', False):
       <script type="text/template" id="login-tpl">
-          <%static:include path="student_account/login.underscore" />
+          <%static:include path="student_account/sso-no-login-no-register.underscore" />
       </script>
     % else:
-      <script type="text/template" id="login-tpl">
-          <%static:include path="student_account/login-no-register.underscore" />
-      </script>
+      % if get_global_settings()['enable_registration_link_on_login']:
+        <script type="text/template" id="login-tpl">
+            <%static:include path="student_account/login.underscore" />
+        </script>
+      % else:
+        <script type="text/template" id="login-tpl">
+            <%static:include path="student_account/login-no-register.underscore" />
+        </script>
+      % endif
     % endif
   % else:
     % for template_name in ["account", "access", "form_field", "institution_login", "institution_register", "password_reset", "hinted_login"]:
@@ -39,9 +45,15 @@
             <%static:include path="student_account/${template_name}.underscore" />
         </script>
     % endfor
-    <script type="text/template" id="login-tpl">
-        <%static:include path="student_account/login-no-register.underscore" />
-    </script>
+    % if get_global_settings().get('sso_disable_login_fields', False):
+      <script type="text/template" id="login-tpl">
+          <%static:include path="student_account/sso-no-login-no-register.underscore" />
+      </script>
+    % else:
+      <script type="text/template" id="login-tpl">
+          <%static:include path="student_account/login-no-register.underscore" />
+      </script>
+    % endif
     <script type="text/template" id="register-tpl">
         <%static:include path="student_account/a--register-disabled.underscore" />
     </script>

--- a/lms/templates/theme-variables-static.html
+++ b/lms/templates/theme-variables-static.html
@@ -4,6 +4,7 @@
 <%! from openedx.core.djangoapps.site_configuration.models import SiteConfiguration %>
 <%! from django.contrib.staticfiles.templatetags.staticfiles import static %>
 <%! from django.utils.translation import ugettext as _ %>
+<%! from datetime import date %>
 
 
 
@@ -119,7 +120,7 @@
   <%
     return {
       'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
-      'footer_copyright_text' : '2016 Company Name. All rights reserved.',  ## leave value empty if you don't want it displayed.
+      'footer_copyright_text' : '©' + date.today().strftime('%Y') + 'Company Name. All rights reserved.',  ## leave value empty if you don't want it displayed.
       'display_edx_disclaimer' : True, ## bool value required
       'edx_disclaimer' : 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.', ## leave value empty if you don't want it displayed.
       'display_poweredby' : True, ## bool value required

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -5,6 +5,7 @@
 <%! from openedx.core.djangoapps.site_configuration.models import SiteConfiguration %>
 <%! from django.contrib.staticfiles.templatetags.staticfiles import static %>
 <%! from django.utils.translation import ugettext as _ %>
+<%! from datetime import date %>
 
 
 
@@ -30,6 +31,7 @@
     'enable_registration_button' : get_value('enable_registration_button', True),
     'enable_registration_link_on_login' : get_value('enable_registration_link_on_login', True),
     'enable_registration_form' : get_value('enable_registration_form', True),
+    'sso_disable_login_fields' : get_value('sso_disable_login_fields', False),
     'fonts_url' : 'https://fonts.googleapis.com/css?family={}|{}:300,300i,400,400i,700,700i,900{}'.format(
       encoded_accent_font, encoded_primary_font, latin_extended),
     'apple_app_id' : '',
@@ -115,7 +117,7 @@
     footer_options = get_current_site_configuration().page_elements.get('footer', {}).get('options', {})
     return {
       'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
-      'footer_copyright_text' : footer_options.get('footer_copyright_text', '© 2017 Company Name. All rights reserved.'),  ## leave value empty if you don't want it displayed.
+      'footer_copyright_text' : footer_options.get('footer_copyright_text', '©' + date.today().strftime('%Y') + ' Company Name. All rights reserved.'),  ## leave value empty if you don't want it displayed.
       'display_edx_disclaimer' : footer_options.get('display_edx_disclaimer', True), ## bool value required
       'edx_disclaimer' : footer_options.get('edx_disclaimer', 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.'), ## leave value empty if you don't want it displayed.
       'display_poweredby' : footer_options.get('display_poweredby', True), ## bool value required
@@ -295,5 +297,31 @@
 <%def name="get_privacy_content()">
   <%
     return get_current_site_configuration().page_elements.get('privacy', {}).get('content', [])
+  %>
+</%def>
+
+## certs settings
+
+<%def name="get_certificates_settings()">
+  <%
+  return {
+    'paper_orientation': get_value('certificates', {}).get('paper_orientation', 'landscape'),
+    'header_logo': get_value('certificates', {}).get('header_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
+    'header_logo_width': get_value('certificates', {}).get('header_logo_width', '240px'),
+    'cert_logo': get_value('certificates', {}).get('cert_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
+    'logo_width': get_value('certificates', {}).get('cert_logo_width', '160px'),
+    'platform_name': get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', 'Platform Name')),
+    'header_text': get_value('certificates', {}).get('header_text', 'Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.'),
+    'short_platform_description': get_value('certificates', {}).get('short_platform_description', ''),
+    'we_hereby_text': get_value('certificates', {}).get('we_hereby_text', 'We hereby certify that:'),
+    'successfully_completed_text': get_value('certificates', {}).get('successfully_completed_text', "successfully completed, received a passing grade, and was awarded this platforms' Honor Code Certificate of Completion in:"),
+    'optional_cert_text': get_value('certificates', {}).get('optional_cert_text', ''),
+    'footer_about_platform_text': get_value('certificates', {}).get('footer_about_platform_text', 'Our platform offers interactive online classes and MOOCs.'),
+    'footer_about_platform_url': get_value('certificates', {}).get('footer_about_platform_url', '#'),
+    'footer_about_accomplishments_text': get_value('certificates', {}).get('footer_about_accomplishments_text', "Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete."),
+    'footer_copyright_text': get_value('certificates', {}).get('footer_copyright_text', ""),
+    'footer_tos_url': get_value('certificates', {}).get('footer_tos_url', "#"),
+    'footer_privacy_url': get_value('certificates', {}).get('footer_privacy_url', "#"),
+  }
   %>
 </%def>


### PR DESCRIPTION
This PR merges in the new code added for the AMC certificates functionality into the AMC customer-specific theme code.

We add the following:

- certificates templates with hooks to theme-variables.html functions that return customisable values to the frontend. These templates also feature our responsive and printer-friendly certificate template.
- certificate view sass styles that accompany the new templates
- theme-variables.html file changes where we add the get_certificates_settings() function that returns options with either values  set up in AMC or, if those are not set, default values.