### PR TITLE
use course org to retrieve site config settings

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -18,7 +18,7 @@
       % if context_course:
       <%
             course_key = context_course.id
-            current_organization = request.user.organizations.first()
+            current_organization = context_course.org
             index_url = reverse('contentstore.views.course_handler', kwargs={'course_key_string': unicode(course_key)})
             course_team_url = reverse('contentstore.views.course_team_handler', kwargs={'course_key_string': unicode(course_key)})
             assets_url = reverse('contentstore.views.assets_handler', kwargs={'course_key_string': unicode(course_key)})
@@ -32,7 +32,7 @@
             advanced_settings_url = reverse('contentstore.views.advanced_settings_handler', kwargs={'course_key_string': unicode(course_key)})
             tabs_url = reverse('contentstore.views.tabs_handler', kwargs={'course_key_string': unicode(course_key)})
             certificates_url = ''
-            if configuration_helpers.get_value_for_org(current_organization.name, "CERTIFICATES_HTML_VIEW", False) and context_course.cert_html_view_enabled:
+            if configuration_helpers.get_value_for_org(current_organization, "CERTIFICATES_HTML_VIEW", False) and context_course.cert_html_view_enabled:
                 certificates_url = reverse('contentstore.views.certificates.certificates_list_handler', kwargs={'course_key_string': unicode(course_key)})
       %>
       <h2 class="info-course">


### PR DESCRIPTION
This solves a problem, when a superuser or staff user is trying to access to a course, but the user isn't associated to an organization. 

Since the course has already an org attached, we should always use it to retrieve the configuration flag.