### PR TITLE
Fix register button error in CSET

### DIFF
--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -59,5 +59,5 @@
             <span class="text"><%- _.sprintf( gettext("New to %(platformName)s?"), context ) %></span>
         </h2>
     </div>
-    <a href="https://getyouredge.org/" class="nav-btn form-toggle"><%- gettext("Create an account") %></a>
+    <a href="https://getyouredge.org/" class="nav-btn"><%- gettext("Create an account") %></a>
 </div>


### PR DESCRIPTION
The `form-toggle` class causes unwanted JavaScript to run and prevents the link from actually working.

When clicking on the link this error shows up:

![image](https://user-images.githubusercontent.com/645156/37833398-3b6763fc-2ebc-11e8-993e-df4842970de0.png)
