### PR TITLE
Trinity: imported course content float fixes

### DIFF
--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -59,3 +59,9 @@
 .a--discovery-search-01__filters {
   display: none;
 }
+
+// Fixes for floated content imported from texasgateway.org
+#seq-content .wrap-instructor-info,
+nav.sequence-bottom {
+  clear: both;
+}

--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -61,7 +61,7 @@
 }
 
 // Fixes for floated content imported from texasgateway.org
-#seq-content .wrap-instructor-info,
+#seq_content .wrap-instructor-info,
 nav.sequence-bottom {
   clear: both;
 }


### PR DESCRIPTION
Trinity is using a lot of float styles and align attributes in their imported course content (they create course content in texasgateway.org and import via OLX that they generate).  Example from their course before import:

![image](https://user-images.githubusercontent.com/1289191/41632295-fce32432-73ed-11e8-857e-ff770e0e0d95.png)


This makes sure prev/next page nav clears the floated content.

Before: prev/next affected by floated content
![image](https://user-images.githubusercontent.com/1289191/41632217-a4020220-73ed-11e8-916f-103655cdff2d.png)


After: instructor UI elements follow cleared floated content
![image](https://user-images.githubusercontent.com/1289191/41632157-6055c70a-73ed-11e8-9470-4d479ca8cd21.png)

There are more fixes needed to handle Trinity's imported content, but this is a start.





  

