### PR TITLE
fix enrollment and beta tester emails

### DIFF
--- a/lms/templates/emails/add_beta_tester_email_message.txt
+++ b/lms/templates/emails/add_beta_tester_email_message.txt
@@ -1,0 +1,30 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+<%
+	course_about_url = 'https://{}/courses/{}/about'.format(request.site, course.id.to_deprecated_string())
+	course_url 			 = 'https://{}/courses/{}/'.format(request.site, course.id.to_deprecated_string())
+%>
+
+${_("Dear {full_name}").format(full_name=full_name)}
+
+${_("You have been invited to be a beta tester for {course_name} at {site_name} by a "
+	"member of the course staff.").format(
+		course_name=course.display_name_with_default_escaped,
+		site_name=request.site
+	)}
+
+% if auto_enroll:
+${_("To start accessing course materials, please visit {course_url}").format(
+		course_url=course_url
+	)}
+% elif course_about_url is not None:
+${_("Visit {course_about_url} to join the course and begin the beta test.").format(course_about_url=course_about_url)}
+% else:
+${_("Visit {site_name} to enroll in the course and begin the beta test.").format(site_name=request.site)}
+% endif
+
+----
+${_("This email was automatically sent from {site_name} to "
+	"{email_address}").format(
+		site_name=request.site, email_address=email_address
+	)}

--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -1,0 +1,49 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+<%
+  registration_url = 'https://{}/register'.format(request.site)
+  course_about_url = 'https://{}/courses/{}/about'.format(request.site, course.id.to_deprecated_string())
+	course_url 			 = 'https://{}/courses/{}/'.format(request.site, course.id.to_deprecated_string())
+%>
+
+${_("Dear student,")}
+
+${_("You have been invited to join {course_name} at {site_name} by a "
+	"member of the course staff.").format(
+		course_name=display_name or course.display_name_with_default_escaped,
+		site_name=request.site
+	)}
+% if is_shib_course:
+% if auto_enroll:
+
+${_("To access the course visit {course_url} and login.").format(course_url=course_url)}
+% elif course_about_url is not None:
+
+${_("To access the course visit {course_about_url} and register for the course.").format(
+		course_about_url=course_about_url)}
+% endif
+% else:
+
+${_("To finish your registration, please visit {registration_url} and fill "
+	"out the registration form making sure to use {email_address} in the E-mail field.").format(
+		registration_url=registration_url,
+		email_address=email_address
+	)}
+% if auto_enroll:
+${_("Once you have registered and activated your account, you will see "
+	"{course_name} listed on your dashboard.").format(
+		course_name=display_name or course.display_name_with_default_escaped
+	)}
+% elif course_about_url is not None:
+${_("Once you have registered and activated your account, visit {course_about_url} "
+	"to join the course.").format(course_about_url=course_about_url)}
+% else:
+${_("You can then enroll in {course_name}.").format(course_name=display_name or course.display_name_with_default_escaped)}
+% endif
+% endif
+
+----
+${_("This email was automatically sent from {site_name} to "
+	"{email_address}").format(
+		site_name=request.site, email_address=email_address
+	)}


### PR DESCRIPTION
This PR is to make enrollment email and beta add emails custom domains aware.

The solution isn't pretty but works, and the issue is high priority because it's being a blocker for Redis and theincorruptibles.

I'm redefining variables in the template, to avoid introducing more changes in the platform core code, without a proper design. We'll need to rework this in the near future.