### PR TITLE
bring back the cert ID and date to the web view

### DIFF
--- a/lms/static/sass/certificates/_certificate-template-01.scss
+++ b/lms/static/sass/certificates/_certificate-template-01.scss
@@ -188,7 +188,6 @@
   }
 
   @media screen {
-    //display: none;
     padding: 0 2em 2em;
     font-size: 0.8rem;
   }

--- a/lms/static/sass/certificates/_certificate-template-01.scss
+++ b/lms/static/sass/certificates/_certificate-template-01.scss
@@ -170,9 +170,27 @@
 
 .a--accomplishment-design-01__certificate-info-print-only {
   overflow: visible;
+  color: #fff;
+
+  .info-upper {
+    @include display(flex);
+    @include align-items(center);
+    margin-bottom: 1em;
+  }
+
+  .info-right {
+    margin-left: auto;
+  }
+
+  a {
+    color: #fff;
+    font-weight: bolder;
+  }
 
   @media screen {
-    display: none;
+    //display: none;
+    padding: 0 2em 2em;
+    font-size: 0.8rem;
   }
 }
 
@@ -305,15 +323,14 @@
     }
 
     &__certificate-info-print-only {
-      @include display(flex);
-      @include align-items(center);
       margin-bottom: 0.7cm;
       font-size: 0.25cm;
       padding: 0 1.1cm;
       color: #fff;
 
-      .info-right {
-        margin-left: auto;
+      .info-upper {
+        @include display(flex);
+        @include align-items(center);
       }
     }
   }

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -61,13 +61,15 @@ cert_org_name = get_certificates_settings().get('certificate_custom_org_name') i
         </div>
       </div>
       <div class="a--accomplishment-design-01__certificate-info-print-only">
-        <div class="info-left">
-          Certificate ID number: <b>${certificate_id_number}</b>
+        <div class="info-upper">
+          <div class="info-left">
+            Certificate ID number: <b>${certificate_id_number}</b>
+          </div>
+          <div class="info-right">
+            Date issued: <b>${certificate_date_issued}</b>
+          </div>
         </div>
-        <div class="info-right">
-          <b>${certificate_date_issued}</b>
-        </div>
-        <div>
+        <div class="info-bottom">
           Verify the authenticity of this certificate at <a href="https://${request.site}/certificates/user/${accomplishment_user_id}/course/${course_id}">https://${request.site}/certificates/user/${accomplishment_user_id}/course/${course_id}</a>
         </div>
       </div>


### PR DESCRIPTION
Per card: https://trello.com/c/Q5dPck1g/2250-35-add-date-issued-to-certificates

The certs had the timestamp and cert ID, but only visible in print. Now it's styled and visible in both print and web view.

Screenshot:
![cert-screen](https://user-images.githubusercontent.com/10602234/42287182-af614dd2-7fb5-11e8-826f-3e0286cea7f3.png)
