### PR TITLE
don’t set the LMS_URL for Intercom in Studio

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -172,8 +172,7 @@ var require = {baseUrl: window.baseUrl};
             created_at: ${user.date_joined.strftime("%s")}, // Signup date as a Unix timestamp
             user_hash: "${intercom_user_hash}",
           %endif
-          app_id: "${intercom_app_id}",
-          "LMS_URL": "${intercom_lms_url}"
+          app_id: "${intercom_app_id}"
         };
       </script>
       <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/e4awi275';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>


### PR DESCRIPTION
Remove the line that sets the LMS_URL for the user from the Studio code. The relevant card with the issue it should fix is this one: https://trello.com/c/YsiCDFTJ/2047-5-intercom-records-showing-tahoeappsemblercom-as-lmsurl-in-details

After (a lot of) investigation, I've come to the conclusion that the AMC React code works well and the variable that gets assigned to the LMS_URL Intercom value is set properly, same as with the LMS part. What Filip and I concluded is that most likely the users LMS_URL value in Intercom gets set to "tahoe.appsembler.com" when the user uses the Studio. Since the user when using Studio is at the tahoe.appsembler.com domain (and not the customers subdomain), the request origin domain is then "tahoe.appsembler.com" and that gets propagated to the Intercom value. This change should fix that.

We should monitor the situation in Intercom to see if any newly created users get the "tahoe.appsembler.com" value as the LMS_URL value. For the existing ones, if this fix works, we can set the correct value manually.