### PR TITLE
Trinity Ficus staging: narrower content column width, course unit nav overflow fix

### DIFF
--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -65,3 +65,11 @@
 nav.sequence-bottom {
   clear: both;
 }
+
+
+/* Set a maximum content XBlock/xmodule width of 700px
+to match styling of content imported from texasgateway.org
+*/
+.xblock-student_view-vertical {
+  max-width: 700px;
+}

--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -75,5 +75,6 @@ to match styling of content imported from texasgateway.org
 }
 
 .xblock-student_view .sequence-list-wrapper {
-  overflow: scroll;
+  overflow-x: scroll;
+  overflow-y: hidden;
 }

--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -73,3 +73,7 @@ to match styling of content imported from texasgateway.org
 .xblock-student_view-vertical {
   max-width: 700px;
 }
+
+.xblock-student_view .sequence-list-wrapper {
+  overflow: scroll;
+}


### PR DESCRIPTION
Little styling changes to match content width styling imported via texasgateway.org content creation.  Also an overflow fix for nav in sections with many many units.  Not super elegant, using overflow:scroll, but it's probably fine for this use case.