### PR TITLE
Sort courses listing to newest (most recent start date) first

### DIFF
--- a/lms/static/js/discovery/discovery_factory.js
+++ b/lms/static/js/discovery/discovery_factory.js
@@ -3,7 +3,7 @@
 
     define('edx-theme-codebase/js/discovery/discovery_factory',
         ['backbone', 'edx-theme-codebase/js/discovery/models/search_state', 'js/discovery/collections/filters',
-        'js/discovery/views/search_form', 'js/discovery/views/courses_listing',
+        'js/discovery/views/search_form', 'edx-theme-codebase/js/discovery/views/courses_listing',
         'js/discovery/views/filter_bar', 'js/discovery/views/refine_sidebar'],
         function(Backbone, SearchState, Filters, SearchForm, CoursesListing, FilterBar, RefineSidebar) {
 

--- a/lms/static/js/discovery/views/courses_listing.js
+++ b/lms/static/js/discovery/views/courses_listing.js
@@ -1,0 +1,30 @@
+;(function (define) {
+
+define([
+    'jquery',
+    'js/discovery/views/courses_listing',
+    'js/discovery/views/course_card'
+], function ($, CoursesListing, CourseCardView) {
+   'use strict';
+
+    return CoursesListing.extend({
+
+        renderItems: function () {
+            var latest = this.model.latest();
+            // custom Trinity sort by most recent start date to least recent
+            latest.sort(function(a, b) {
+                return new Date(b.attributes.start).getTime() - new Date(a.attributes.start).getTime();
+            });
+
+            var items = latest.map(function (result) {
+                var item = new CourseCardView({ model: result });
+                return item.render().el;
+            }, this);
+            this.$list.append(items);
+        }
+    });
+
+});
+
+
+})(define || RequireJS.define);


### PR DESCRIPTION
Revise courses page sort order, putting most recent start date first. 
We had originally sorted most recent start date last, then I had removed that thinking that default Open edX put most recent start date first.  But it doesn't—it's essentially random when there's no search term.  