### PR TITLE
Enable localization on AMC

### DIFF
--- a/lms/templates/design-templates/footer/_footer-appsembler-01.html
+++ b/lms/templates/design-templates/footer/_footer-appsembler-01.html
@@ -1,7 +1,7 @@
 <%page args="footer_links, footer_logo, footer_logo_alt_text, footer_copyright_text, display_edx_disclaimer, edx_disclaimer, display_poweredby" />
 <%namespace file='/theme-variables.html' import="get_footer_settings" />
 <%namespace name='static' file='/static_content.html'/>
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 <%! from django.utils.translation import ugettext as _ %>
 
 <footer class="a--footer">
@@ -29,7 +29,7 @@
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${return_translation(item['link_title'])}</a>
+              >${item['link_title'] | translate}</a>
             </li>
             % endfor
           </ul>

--- a/lms/templates/design-templates/footer/_footer-appsembler-01.html
+++ b/lms/templates/design-templates/footer/_footer-appsembler-01.html
@@ -1,0 +1,58 @@
+<%page args="footer_links, footer_logo, footer_logo_alt_text, footer_copyright_text, display_edx_disclaimer, edx_disclaimer, display_poweredby" />
+<%namespace file='/theme-variables.html' import="get_footer_settings" />
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/theme-variables.html' import="return_translation" />
+<%! from django.utils.translation import ugettext as _ %>
+
+<footer class="a--footer">
+  <div class="bs-container a--container a--footer__container">
+    <div class="a--footer__main-wrapper">
+      <div class="a--footer__main">
+        <div class="a--footer__logo">
+          <img src="${footer_logo}" alt="${footer_logo_alt_text}"/>
+        </div>
+        <div class="a--footer__nav">
+          <p class="a--footer__copyright-text">
+            ${footer_copyright_text}
+          </p>
+          <ul class="a--footer__links-container">
+            % if get_footer_settings().get('display_app_link', False):
+              <li>
+                <a href="${get_footer_settings().get('app_url')}" target="_blank">
+                  <img class="app-store" alt="${_("Apple app on Apple Store")}" src="/static/images/app/app_store_badge_135x40.svg" style="height: 30px; width: auto;">
+                </a>
+              </li>
+            % endif
+            % for item in footer_links:
+            <li class="">
+              <a href="${item['link_URL']}" class="${item['special_class']}"
+              % if item['open_in_new_tab']:
+                target="_blank"
+              % endif
+              >${return_translation(item['link_title'])}</a>
+            </li>
+            % endfor
+          </ul>
+        </div>
+      </div>
+      % if display_poweredby:
+        <div class="a--footer__powered-by">
+          <p>
+            Powered by:
+          </p>
+          <a href="https://www.appsembler.com" target="_blank" id="footer-appsembler-logo" alt="Appsembler">
+            <img src="${static.url('images/appsembler-logo-positive.svg')}" alt="Appsembler" />
+          </a>
+          <a href="http://open.edx.org" target="_blank" id="footer-openedx-logo" alt="Open edX">
+            <img src="${static.url('images/openedx-logo.svg')}" alt="Open edX" />
+          </a>
+        </div>
+      % endif
+    </div>
+    % if display_edx_disclaimer:
+      <div class="a--footer__edx-disclaimer">
+        ${edx_disclaimer}
+      </div>
+    % endif
+  </div>
+</footer>

--- a/lms/templates/design-templates/footer/_footer-appsembler-01.html
+++ b/lms/templates/design-templates/footer/_footer-appsembler-01.html
@@ -29,7 +29,7 @@
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${item['link_title'] | translate}</a>
+              >${translate(item['link_title'])}</a>
             </li>
             % endfor
           </ul>

--- a/lms/templates/design-templates/header/_header-appsembler-01.html
+++ b/lms/templates/design-templates/header/_header-appsembler-01.html
@@ -3,7 +3,7 @@
 from django.utils.translation import ugettext as _
 %>
 <%namespace name='static' file='/static_content.html'/>
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 ## mako
 
 <!-- top navigation -->
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${return_translation(item['link_title'])}</a>
+              >${item['link_title'] | translate}</a>
             </li>
             % endfor
           </ul>
@@ -65,7 +65,7 @@ from django.utils.translation import ugettext as _
                     % if item['open_in_new_tab']:
                       target="_blank"
                     % endif
-                    >${return_translation(item['link_title'])}</a>
+                    >${item['link_title'] | translate}</a>
                   </li>
                 % endfor
                 <% first_slideout_item = False %>

--- a/lms/templates/design-templates/header/_header-appsembler-01.html
+++ b/lms/templates/design-templates/header/_header-appsembler-01.html
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${item['link_title'] | translate}</a>
+              >${translate(item['link_title'])}</a>
             </li>
             % endfor
           </ul>
@@ -65,7 +65,7 @@ from django.utils.translation import ugettext as _
                     % if item['open_in_new_tab']:
                       target="_blank"
                     % endif
-                    >${item['link_title'] | translate}</a>
+                    >${translate(item['link_title'])}</a>
                   </li>
                 % endfor
                 <% first_slideout_item = False %>

--- a/lms/templates/design-templates/header/_header-appsembler-01.html
+++ b/lms/templates/design-templates/header/_header-appsembler-01.html
@@ -1,0 +1,80 @@
+<%page args="user_authenticated, user_name, logo_positive, logo_negative, logo_url, display_shopping_cart, shopping_cart_url, display_course_name, course_number, course_name, menu_items, slideout_menu_items" />
+<%!
+from django.utils.translation import ugettext as _
+%>
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/theme-variables.html' import="return_translation" />
+## mako
+
+<!-- top navigation -->
+<section class="a--header-design-01 a--site-nav">
+  <div class="bs-container a--container a--site-nav__container">
+    <h1 class="a--site-nav__group-left">
+      <a href="${logo_url}" class="a--site-nav__logo__container a--site-nav__logo__positive">
+        <img class="a--site-nav__logo a--logo-full" src="${logo_positive}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}">
+      </a>
+      <a href="${logo_url}" class="a--site-nav__logo__container a--site-nav__logo__negative">
+        <img class="a--site-nav__logo a--logo-full" src="${logo_negative}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}">
+      </a>
+      % if display_course_name:
+      <div class="a--site-nav__course-name">
+        <span>${course_number}</span>${course_name}
+      </div>
+      % endif
+    </h1>
+    <nav class="a--site-nav__group-right" id="site-menu">
+      <ul class="a--site-menu__container">
+        % for menu_group in menu_items:
+        <li class="a--site-menu__group">
+          <ul>
+            % for item in menu_group:
+            <li class="${item['special_class']}">
+              <a href="${item['link_URL']}"
+              % if item['open_in_new_tab']:
+                target="_blank"
+              % endif
+              >${return_translation(item['link_title'])}</a>
+            </li>
+            % endfor
+          </ul>
+        </li>
+        % endfor
+        % if user_authenticated:
+        <li class="a--site-menu__group a--user-avatar">
+          ${_("Welcome")}, <span>${user_name}</span>.
+        </li>
+        % endif
+        <li class="a--site-menu__group a--slide-menu">
+          <button type="button" id="site-menu-toggle" class="a--button a--site-nav__mobile-toggle" aria-label="toggle menu">
+            <span class="a--toggle-bar"></span>
+            <span class="a--toggle-bar"></span>
+            <span class="a--toggle-bar"></span>
+            <span class="a--toggle-pulsar a--toggle-pulsar__1"></span>
+            <span class="a--toggle-pulsar a--toggle-pulsar__2"></span>
+          </button>
+          <ul class="a--slide-menu__container" id="slide-menu">
+            <% first_slideout_item = True %>
+            % for menu_group in slideout_menu_items:
+              % if menu_group and menu_group[0]['link_title']:
+                % if not first_slideout_item:
+                  <li class="a--spacer"></li>
+                % endif
+                % for item in menu_group:
+                  <li class="${item['special_class']}">
+                    <a href="${item['link_URL']}"
+                    % if item['open_in_new_tab']:
+                      target="_blank"
+                    % endif
+                    >${return_translation(item['link_title'])}</a>
+                  </li>
+                % endfor
+                <% first_slideout_item = False %>
+              % endif
+            % endfor
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</section>
+		<!-- end of top navigation -->

--- a/lms/templates/design-templates/header/_header-appsembler-02.html
+++ b/lms/templates/design-templates/header/_header-appsembler-02.html
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${item['link_title'] | translate}</a>
+              >${translate(item['link_title'])}</a>
             </li>
             % endfor
           </ul>
@@ -63,7 +63,7 @@ from django.utils.translation import ugettext as _
                     % if item['open_in_new_tab']:
                       target="_blank"
                     % endif
-                    >${item['link_title'] | translate}</a>
+                    >${translate(item['link_title'])}</a>
                   </li>
                 % endfor
                 <% first_slideout_item = False %>

--- a/lms/templates/design-templates/header/_header-appsembler-02.html
+++ b/lms/templates/design-templates/header/_header-appsembler-02.html
@@ -3,7 +3,7 @@
 from django.utils.translation import ugettext as _
 %>
 <%namespace name='static' file='/static_content.html'/>
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 ## mako
 
 <!-- top navigation -->
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${return_translation(item['link_title'])}</a>
+              >${item['link_title'] | translate}</a>
             </li>
             % endfor
           </ul>
@@ -63,7 +63,7 @@ from django.utils.translation import ugettext as _
                     % if item['open_in_new_tab']:
                       target="_blank"
                     % endif
-                    >${return_translation(item['link_title'])}</a>
+                    >${item['link_title'] | translate}</a>
                   </li>
                 % endfor
                 <% first_slideout_item = False %>

--- a/lms/templates/design-templates/header/_header-appsembler-02.html
+++ b/lms/templates/design-templates/header/_header-appsembler-02.html
@@ -1,0 +1,78 @@
+<%page args="user_authenticated, user_name, logo_positive, logo_negative, logo_url, display_shopping_cart, shopping_cart_url, display_course_name, course_number, course_name, menu_items, slideout_menu_items" />
+<%!
+from django.utils.translation import ugettext as _
+%>
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/theme-variables.html' import="return_translation" />
+## mako
+
+<!-- top navigation -->
+<section class="a--header-design-02 a--site-nav">
+  <div class="bs-container a--container a--site-nav__container">
+    <h1 class="a--site-nav__group-left">
+      <a href="${logo_url}" class="a--site-nav__logo__container a--site-nav__logo__positive">
+        <img class="a--site-nav__logo a--logo-full" src="${logo_positive}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}">
+      </a>
+      <a href="${logo_url}" class="a--site-nav__logo__container a--site-nav__logo__negative">
+        <img class="a--site-nav__logo a--logo-full" src="${logo_negative}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}">
+      </a>
+      % if display_course_name:
+      <div class="a--site-nav__course-name">
+        <span>${course_number}</span>${course_name}
+      </div>
+      % endif
+    </h1>
+    <nav class="a--site-nav__group-right" id="site-menu">
+      <ul class="a--site-menu__container">
+        % for menu_group in menu_items:
+        <li class="a--site-menu__group">
+          <ul>
+            % for item in menu_group:
+            <li class="${item['special_class']}">
+              <a href="${item['link_URL']}"
+              % if item['open_in_new_tab']:
+                target="_blank"
+              % endif
+              >${return_translation(item['link_title'])}</a>
+            </li>
+            % endfor
+          </ul>
+        </li>
+        % endfor
+        % if user_authenticated:
+        <li class="a--site-menu__group a--user-avatar">
+          ${_("Welcome")}, <span>${user_name}</span>.
+        </li>
+        % endif
+        <li class="a--site-menu__group a--slide-menu">
+          <button type="button" id="site-menu-toggle" class="a--button a--site-nav__mobile-toggle" aria-label="toggle menu">
+            <span class="a--toggle-bar"></span>
+            <span class="a--toggle-bar"></span>
+            <span class="a--toggle-text">${_("MENU")}</span>
+          </button>
+          <ul class="a--slide-menu__container" id="slide-menu">
+            <% first_slideout_item = True %>
+            % for menu_group in slideout_menu_items:
+              % if menu_group and menu_group[0]['link_title']:
+                % if not first_slideout_item:
+                  <li class="a--spacer"></li>
+                % endif
+                % for item in menu_group:
+                  <li class="${item['special_class']}">
+                    <a href="${item['link_URL']}"
+                    % if item['open_in_new_tab']:
+                      target="_blank"
+                    % endif
+                    >${return_translation(item['link_title'])}</a>
+                  </li>
+                % endfor
+                <% first_slideout_item = False %>
+              % endif
+            % endfor
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</section>
+		<!-- end of top navigation -->

--- a/lms/templates/page-builder/elements/_content-block.html
+++ b/lms/templates/page-builder/elements/_content-block.html
@@ -1,0 +1,7 @@
+## mako
+<%page args="options" />
+<%namespace file='/theme-variables.html' import="return_translation" />
+
+<div class="amc--element--content-block amc--style-classes ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}">
+  ${return_translation(options['content'])}
+</div>

--- a/lms/templates/page-builder/elements/_content-block.html
+++ b/lms/templates/page-builder/elements/_content-block.html
@@ -3,5 +3,5 @@
 <%namespace file='/theme-variables.html' import="translate" />
 
 <div class="amc--element--content-block amc--style-classes ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}">
-  ${options['content'] | translate}
+  ${translate(options['content'])}
 </div>

--- a/lms/templates/page-builder/elements/_content-block.html
+++ b/lms/templates/page-builder/elements/_content-block.html
@@ -1,7 +1,7 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 <div class="amc--element--content-block amc--style-classes ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}">
-  ${return_translation(options['content'])}
+  ${options['content'] | translate}
 </div>

--- a/lms/templates/page-builder/elements/_courses-listing.html
+++ b/lms/templates/page-builder/elements/_courses-listing.html
@@ -1,0 +1,16 @@
+<%page args="options, courses" />
+
+<%
+  course_count = 0
+%>
+
+<section class="amc--element--courses-listing courses-listing ${options['tile-type']}--parent-element amc--style-classes ${options['text-alignment']}">
+  % if not courses is UNDEFINED:
+    % for course in courses:
+      % if not course_count == options['num-of-courses']:
+        <%include file="/design-templates/live-blocks/single-course/_${options['tile-type']}.html" args="course=course" />
+        <% course_count = course_count + 1 %>
+      % endif
+    % endfor
+  % endif
+</section>

--- a/lms/templates/page-builder/elements/_cta-button.html
+++ b/lms/templates/page-builder/elements/_cta-button.html
@@ -1,6 +1,6 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 <%
   element_style = ""
@@ -8,5 +8,5 @@
 %>
 
 <a class="amc--element--cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="${options['url']}">
-  ${return_translation(options['text-content'])}
+  ${options['text-content'] | translate}
 </a>

--- a/lms/templates/page-builder/elements/_cta-button.html
+++ b/lms/templates/page-builder/elements/_cta-button.html
@@ -1,0 +1,12 @@
+## mako
+<%page args="options" />
+<%namespace file='/theme-variables.html' import="return_translation" />
+
+<%
+  element_style = ""
+  element_style = element_style + "color: " + options['text-color'] + ";" + element_style + "background-color: " + options['bg-color'] + ";" + element_style + "border-color: " + options['border-color'] + ";"
+%>
+
+<a class="amc--element--cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="${options['url']}">
+  ${return_translation(options['text-content'])}
+</a>

--- a/lms/templates/page-builder/elements/_cta-button.html
+++ b/lms/templates/page-builder/elements/_cta-button.html
@@ -8,5 +8,5 @@
 %>
 
 <a class="amc--element--cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="${options['url']}">
-  ${options['text-content'] | translate}
+  ${translate(options['text-content'])}
 </a>

--- a/lms/templates/page-builder/elements/_heading.html
+++ b/lms/templates/page-builder/elements/_heading.html
@@ -1,6 +1,6 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 <%! from django.utils import translation %>
 
 <%
@@ -9,5 +9,5 @@
 %>
 
 <h2 class="amc--element--heading amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
-  ${return_translation(options['text-content'])}
+  ${options['text-content'] | translate}
 </h2>

--- a/lms/templates/page-builder/elements/_heading.html
+++ b/lms/templates/page-builder/elements/_heading.html
@@ -1,0 +1,13 @@
+## mako
+<%page args="options" />
+<%namespace file='/theme-variables.html' import="return_translation" />
+<%! from django.utils import translation %>
+
+<%
+  element_style = ""
+  element_style = element_style + "color: " + options['text-color'] + ";"
+%>
+
+<h2 class="amc--element--heading amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
+  ${return_translation(options['text-content'])}
+</h2>

--- a/lms/templates/page-builder/elements/_heading.html
+++ b/lms/templates/page-builder/elements/_heading.html
@@ -9,5 +9,5 @@
 %>
 
 <h2 class="amc--element--heading amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
-  ${options['text-content'] | translate}
+  ${translate(options['text-content'])}
 </h2>

--- a/lms/templates/page-builder/elements/_image-graphic.html
+++ b/lms/templates/page-builder/elements/_image-graphic.html
@@ -1,11 +1,11 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 % if options['link-url']:
   <a class="amc--element--image-graphic__link-wrapper" href="${options['link-url']}">
 % endif
-  <img src="${options['image-file']}" role="presentation" alt="${return_translation(options['image-alt-text'])}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
+  <img src="${options['image-file']}" role="presentation" alt="${options['image-alt-text'] | translate}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
 % if options['link-url']:
   </a>
 % endif

--- a/lms/templates/page-builder/elements/_image-graphic.html
+++ b/lms/templates/page-builder/elements/_image-graphic.html
@@ -5,7 +5,7 @@
 % if options['link-url']:
   <a class="amc--element--image-graphic__link-wrapper" href="${options['link-url']}">
 % endif
-  <img src="${options['image-file']}" role="presentation" alt="${options['image-alt-text'] | translate}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
+  <img src="${options['image-file']}" role="presentation" alt="${translate(options['image-alt-text'])}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
 % if options['link-url']:
   </a>
 % endif

--- a/lms/templates/page-builder/elements/_image-graphic.html
+++ b/lms/templates/page-builder/elements/_image-graphic.html
@@ -1,0 +1,11 @@
+## mako
+<%page args="options" />
+<%namespace file='/theme-variables.html' import="return_translation" />
+
+% if options['link-url']:
+  <a class="amc--element--image-graphic__link-wrapper" href="${options['link-url']}">
+% endif
+  <img src="${options['image-file']}" role="presentation" alt="${return_translation(options['image-alt-text'])}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
+% if options['link-url']:
+  </a>
+% endif

--- a/lms/templates/page-builder/elements/_paragraph.html
+++ b/lms/templates/page-builder/elements/_paragraph.html
@@ -1,0 +1,14 @@
+## mako
+<%page args="options" />
+<%! from django.utils import translation %>
+<%namespace file='/theme-variables.html' import="return_translation" />
+
+<%
+  element_style = ""
+  element_style = element_style + "color: " + options['text-color'] + ";"
+  current_language = translation.get_language()
+%>
+
+<p class="amc--element--paragraph-text amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
+  ${return_translation(options['text-content'])}
+</p>

--- a/lms/templates/page-builder/elements/_paragraph.html
+++ b/lms/templates/page-builder/elements/_paragraph.html
@@ -10,5 +10,5 @@
 %>
 
 <p class="amc--element--paragraph-text amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
-  ${options['text-content'] | translate}
+  ${translate(options['text-content'])}
 </p>

--- a/lms/templates/page-builder/elements/_paragraph.html
+++ b/lms/templates/page-builder/elements/_paragraph.html
@@ -1,7 +1,7 @@
 ## mako
 <%page args="options" />
 <%! from django.utils import translation %>
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 <%
   element_style = ""
@@ -10,5 +10,5 @@
 %>
 
 <p class="amc--element--paragraph-text amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
-  ${return_translation(options['text-content'])}
+  ${options['text-content'] | translate}
 </p>

--- a/lms/templates/page-builder/elements/_paragraph.html
+++ b/lms/templates/page-builder/elements/_paragraph.html
@@ -6,7 +6,6 @@
 <%
   element_style = ""
   element_style = element_style + "color: " + options['text-color'] + ";"
-  current_language = translation.get_language()
 %>
 
 <p class="amc--element--paragraph-text amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">

--- a/lms/templates/page-builder/elements/_popup-video-cta-button.html
+++ b/lms/templates/page-builder/elements/_popup-video-cta-button.html
@@ -1,0 +1,21 @@
+## mako
+<%page args="options" />
+<%namespace file='/theme-variables.html' import="return_translation" />
+
+<%
+  element_style = ""
+  element_style = element_style + "color: " + options['text-color'] + ";" + element_style + "background-color: " + options['bg-color'] + ";" + element_style + "border-color: " + options['border-color'] + ";"
+%>
+
+<a class="amc--element--popup-video-cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="#" data-toggle="modal" data-target="#${options['youtube-video-id']}Modal">
+  ${return_translation(options['text-content'])}
+</a>
+
+<div class="modal a--modal a--modal__video fade" id="${options['youtube-video-id']}Modal" tabindex="-1" role="dialog" aria-labelledby="${options['youtube-video-id']}Modal">
+  <div class="a--modal__outer-container">
+    <div class="a--modal__video__container bs-container a--container">
+      <button type="button" class="a--modal__close-button" id="a--video-modal-close-${options['youtube-video-id']}" data-dismiss="modal" aria-label="Close"><i class="fa fa-remove"></i></button>
+      <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe class="youtube-modal-iframe" id="${options['youtube-video-id']}" src='https://www.youtube.com/embed/${options['youtube-video-id']}?rel=0&controls=0&showinfo=0&enablejsapi=1' frameborder='0' allowfullscreen></iframe></div>
+    </div>
+  </div>
+</div>

--- a/lms/templates/page-builder/elements/_popup-video-cta-button.html
+++ b/lms/templates/page-builder/elements/_popup-video-cta-button.html
@@ -8,7 +8,7 @@
 %>
 
 <a class="amc--element--popup-video-cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="#" data-toggle="modal" data-target="#${options['youtube-video-id']}Modal">
-  ${options['text-content'] | translate}
+  ${translate(options['text-content'])}
 </a>
 
 <div class="modal a--modal a--modal__video fade" id="${options['youtube-video-id']}Modal" tabindex="-1" role="dialog" aria-labelledby="${options['youtube-video-id']}Modal">

--- a/lms/templates/page-builder/elements/_popup-video-cta-button.html
+++ b/lms/templates/page-builder/elements/_popup-video-cta-button.html
@@ -1,6 +1,6 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 <%
   element_style = ""
@@ -8,7 +8,7 @@
 %>
 
 <a class="amc--element--popup-video-cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="#" data-toggle="modal" data-target="#${options['youtube-video-id']}Modal">
-  ${return_translation(options['text-content'])}
+  ${options['text-content'] | translate}
 </a>
 
 <div class="modal a--modal a--modal__video fade" id="${options['youtube-video-id']}Modal" tabindex="-1" role="dialog" aria-labelledby="${options['youtube-video-id']}Modal">

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -6,12 +6,23 @@
 <%! from django.contrib.staticfiles.templatetags.staticfiles import static %>
 <%! from django.utils.translation import ugettext as _ %>
 <%! from datetime import date %>
+<%! from django.utils import translation %>
 
 
 
 <%!
   theme_name = "eucalyptus-theme-codebase"
+  current_language = translation.get_language()
+  site_default_language = get_value('site_default_language', "en")
 %>
+
+<%def name="return_translation(translations_object)">
+  % if (isinstance(translations_object, dict)):
+    ${translations_object.get(current_language, translations_object.get(site_default_language, ""))}
+  % else:
+    ${translations_object}
+  % endif
+</%def>
 
 
 
@@ -74,9 +85,9 @@
 <%def name="get_header_footer_templates()">
   <%
   return {
-    'header_template' : 'design-templates/header/_header-appsembler-{}.html'.format(
+    'header_template' : '/design-templates/header/_header-appsembler-{}.html'.format(
       get_current_site_configuration().page_elements.get('header', {}).get('type', '01')), ## required
-    'footer_template' : 'design-templates/footer/_footer-appsembler-{}.html'.format(
+    'footer_template' : '/design-templates/footer/_footer-appsembler-{}.html'.format(
       get_current_site_configuration().page_elements.get('footer', {}).get('type', '01')), ## required
   }
   %>

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -9,29 +9,21 @@
 <%! from django.utils import translation %>
 
 
-
 <%!
   theme_name = "eucalyptus-theme-codebase"
   current_language = translation.get_language()
   site_default_language = get_value('site_default_language', "en")
 %>
 
-<%def name="return_translation(translations_object)">
-  % if (isinstance(translations_object, dict)):
-    ${translations_object.get(current_language, translations_object.get(site_default_language, ""))}
-  % else:
-    ${translations_object}
-  % endif
-</%def>
 
-<%def name="return_translation_to_var(translations_object)">
+<%def name="translate(translations_object)">
   % if (isinstance(translations_object, dict)):
     <%
-      return "%s" % (translations_object.get(current_language, translations_object.get(site_default_language, "")))
+      return str(translations_object.get(current_language, translations_object.get(site_default_language, "")))
     %>
   % else:
     <%
-      return "%s" % (translations_object)
+      return str(translations_object)
     %>
   % endif
 </%def>
@@ -140,9 +132,9 @@
     footer_options = get_current_site_configuration().page_elements.get('footer', {}).get('options', {})
     return {
       'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
-      'footer_copyright_text' : return_translation_to_var(footer_options.get('footer_copyright_text', '©' + date.today().strftime('%Y') + ' Company Name. All rights reserved.')),  ## leave value empty if you don't want it displayed.
+      'footer_copyright_text' : translate(footer_options.get('footer_copyright_text', '©' + date.today().strftime('%Y') + ' Company Name. All rights reserved.')),  ## leave value empty if you don't want it displayed.
       'display_edx_disclaimer' : footer_options.get('display_edx_disclaimer', True), ## bool value required
-      'edx_disclaimer' : return_translation_to_var(footer_options.get('edx_disclaimer', 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')), ## leave value empty if you don't want it displayed.
+      'edx_disclaimer' : translate(footer_options.get('edx_disclaimer', 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')), ## leave value empty if you don't want it displayed.
       'display_poweredby' : footer_options.get('display_poweredby', True), ## bool value required
       'display_app_link' : footer_options.get('display_app_link', False),
       'app_url' : footer_options.get('app_url', '')
@@ -333,21 +325,21 @@
     'header_logo_width': get_value('certificates', {}).get('header_logo_width', '240px'),
     'cert_logo': get_value('certificates', {}).get('cert_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
     'logo_width': get_value('certificates', {}).get('cert_logo_width', '160px'),
-    'platform_name': return_translation_to_var(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', 'Platform Name'))),
-    'header_text': return_translation_to_var(get_value('certificates', {}).get('header_text', 'Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
-    'short_platform_description': return_translation_to_var(get_value('certificates', {}).get('short_platform_description', '')),
-    'we_hereby_text': return_translation_to_var(get_value('certificates', {}).get('we_hereby_text', 'We hereby certify that:')),
-    'successfully_completed_text': return_translation_to_var(get_value('certificates', {}).get('successfully_completed_text', "successfully completed, received a passing grade, and was awarded this platforms' Honor Code Certificate of Completion in:")),
-    'optional_cert_text': return_translation_to_var(get_value('certificates', {}).get('optional_cert_text', '')),
-    'footer_about_platform_text': return_translation_to_var(get_value('certificates', {}).get('footer_about_platform_text', 'Our platform offers interactive online classes and MOOCs.')),
+    'platform_name': translate(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', 'Platform Name'))),
+    'header_text': translate(get_value('certificates', {}).get('header_text', 'Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
+    'short_platform_description': translate(get_value('certificates', {}).get('short_platform_description', '')),
+    'we_hereby_text': translate(get_value('certificates', {}).get('we_hereby_text', 'We hereby certify that:')),
+    'successfully_completed_text': translate(get_value('certificates', {}).get('successfully_completed_text', "successfully completed, received a passing grade, and was awarded this platforms' Honor Code Certificate of Completion in:")),
+    'optional_cert_text': translate(get_value('certificates', {}).get('optional_cert_text', '')),
+    'footer_about_platform_text': translate(get_value('certificates', {}).get('footer_about_platform_text', 'Our platform offers interactive online classes and MOOCs.')),
     'footer_about_platform_url': get_value('certificates', {}).get('footer_about_platform_url', '#'),
-    'footer_about_accomplishments_text': return_translation_to_var(get_value('certificates', {}).get('footer_about_accomplishments_text', "Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.")),
-    'footer_copyright_text': return_translation_to_var(get_value('certificates', {}).get('footer_copyright_text', "")),
+    'footer_about_accomplishments_text': translate(get_value('certificates', {}).get('footer_about_accomplishments_text', "Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.")),
+    'footer_copyright_text': translate(get_value('certificates', {}).get('footer_copyright_text', "")),
     'footer_tos_url': get_value('certificates', {}).get('footer_tos_url', "#"),
     'footer_privacy_url': get_value('certificates', {}).get('footer_privacy_url', "#"),
     'accomplishment_icon': get_value('certificates', {}).get('cert_accomplishment_icon', ''),
     'accomplishment_icon_width': get_value('certificates', {}).get('cert_accomplishment_icon_width', '60px'),
-    'certificate_custom_org_name': return_translation_to_var(get_value('certificates', {}).get('certificate_custom_org_name', "")),
+    'certificate_custom_org_name': translate(get_value('certificates', {}).get('certificate_custom_org_name', "")),
   }
   %>
 </%def>

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -24,6 +24,18 @@
   % endif
 </%def>
 
+<%def name="return_translation_to_var(translations_object)">
+  % if (isinstance(translations_object, dict)):
+    <%
+      return "%s" % (translations_object.get(current_language, translations_object.get(site_default_language, "")))
+    %>
+  % else:
+    <%
+      return "%s" % (translations_object)
+    %>
+  % endif
+</%def>
+
 
 
 ## =======================================================
@@ -128,9 +140,9 @@
     footer_options = get_current_site_configuration().page_elements.get('footer', {}).get('options', {})
     return {
       'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
-      'footer_copyright_text' : footer_options.get('footer_copyright_text', '©' + date.today().strftime('%Y') + ' Company Name. All rights reserved.'),  ## leave value empty if you don't want it displayed.
+      'footer_copyright_text' : return_translation_to_var(footer_options.get('footer_copyright_text', '©' + date.today().strftime('%Y') + ' Company Name. All rights reserved.')),  ## leave value empty if you don't want it displayed.
       'display_edx_disclaimer' : footer_options.get('display_edx_disclaimer', True), ## bool value required
-      'edx_disclaimer' : footer_options.get('edx_disclaimer', 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.'), ## leave value empty if you don't want it displayed.
+      'edx_disclaimer' : return_translation_to_var(footer_options.get('edx_disclaimer', 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')), ## leave value empty if you don't want it displayed.
       'display_poweredby' : footer_options.get('display_poweredby', True), ## bool value required
       'display_app_link' : footer_options.get('display_app_link', False),
       'app_url' : footer_options.get('app_url', '')
@@ -321,21 +333,21 @@
     'header_logo_width': get_value('certificates', {}).get('header_logo_width', '240px'),
     'cert_logo': get_value('certificates', {}).get('cert_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
     'logo_width': get_value('certificates', {}).get('cert_logo_width', '160px'),
-    'platform_name': get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', 'Platform Name')),
-    'header_text': get_value('certificates', {}).get('header_text', 'Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.'),
-    'short_platform_description': get_value('certificates', {}).get('short_platform_description', ''),
-    'we_hereby_text': get_value('certificates', {}).get('we_hereby_text', 'We hereby certify that:'),
-    'successfully_completed_text': get_value('certificates', {}).get('successfully_completed_text', "successfully completed, received a passing grade, and was awarded this platforms' Honor Code Certificate of Completion in:"),
-    'optional_cert_text': get_value('certificates', {}).get('optional_cert_text', ''),
-    'footer_about_platform_text': get_value('certificates', {}).get('footer_about_platform_text', 'Our platform offers interactive online classes and MOOCs.'),
+    'platform_name': return_translation_to_var(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', 'Platform Name'))),
+    'header_text': return_translation_to_var(get_value('certificates', {}).get('header_text', 'Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
+    'short_platform_description': return_translation_to_var(get_value('certificates', {}).get('short_platform_description', '')),
+    'we_hereby_text': return_translation_to_var(get_value('certificates', {}).get('we_hereby_text', 'We hereby certify that:')),
+    'successfully_completed_text': return_translation_to_var(get_value('certificates', {}).get('successfully_completed_text', "successfully completed, received a passing grade, and was awarded this platforms' Honor Code Certificate of Completion in:")),
+    'optional_cert_text': return_translation_to_var(get_value('certificates', {}).get('optional_cert_text', '')),
+    'footer_about_platform_text': return_translation_to_var(get_value('certificates', {}).get('footer_about_platform_text', 'Our platform offers interactive online classes and MOOCs.')),
     'footer_about_platform_url': get_value('certificates', {}).get('footer_about_platform_url', '#'),
-    'footer_about_accomplishments_text': get_value('certificates', {}).get('footer_about_accomplishments_text', "Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete."),
-    'footer_copyright_text': get_value('certificates', {}).get('footer_copyright_text', ""),
+    'footer_about_accomplishments_text': return_translation_to_var(get_value('certificates', {}).get('footer_about_accomplishments_text', "Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.")),
+    'footer_copyright_text': return_translation_to_var(get_value('certificates', {}).get('footer_copyright_text', "")),
     'footer_tos_url': get_value('certificates', {}).get('footer_tos_url', "#"),
     'footer_privacy_url': get_value('certificates', {}).get('footer_privacy_url', "#"),
     'accomplishment_icon': get_value('certificates', {}).get('cert_accomplishment_icon', ''),
     'accomplishment_icon_width': get_value('certificates', {}).get('cert_accomplishment_icon_width', '60px'),
-    'certificate_custom_org_name': get_value('certificates', {}).get('certificate_custom_org_name', ""),
+    'certificate_custom_org_name': return_translation_to_var(get_value('certificates', {}).get('certificate_custom_org_name', "")),
   }
   %>
 </%def>

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -4,9 +4,10 @@
 <%! from openedx.core.djangoapps.site_configuration.helpers import get_current_site_configuration, get_value %>
 <%! from openedx.core.djangoapps.site_configuration.models import SiteConfiguration %>
 <%! from django.contrib.staticfiles.templatetags.staticfiles import static %>
+<%! from django.utils.encoding import force_text %>
+<%! from django.utils import translation %>
 <%! from django.utils.translation import ugettext as _ %>
 <%! from datetime import date %>
-<%! from django.utils import translation %>
 
 
 <%!
@@ -19,11 +20,11 @@
 <%def name="translate(translations_object)">
   % if (isinstance(translations_object, dict)):
     <%
-      return str(translations_object.get(current_language, translations_object.get(site_default_language, "")))
+      return force_text(translations_object.get(current_language, translations_object.get(site_default_language, "")))
     %>
   % else:
     <%
-      return str(translations_object)
+      return force_text(translations_object)
     %>
   % endif
 </%def>

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -12,15 +12,15 @@
 
 <%!
   theme_name = "eucalyptus-theme-codebase"
-  current_language = translation.get_language()
-  site_default_language = get_value('site_default_language', "en")
 %>
 
 
 <%def name="translate(translations_object)">
   % if (isinstance(translations_object, dict)):
     <%
-      return force_text(translations_object.get(current_language, translations_object.get(site_default_language, "")))
+      current_language = translation.get_language()
+      site_default_language = get_value('site_default_language', 'en')
+      return force_text(translations_object.get(current_language, translations_object.get(site_default_language, '')))
     %>
   % else:
     <%


### PR DESCRIPTION
Ok, so here we go - here's a PR that brings translation capabilities in Tahoe to the theme side.
The goals for this addition to the theme codebase are:
- make the theme-variables.html template aware of the current browser language that Django detects
- **if** the translation exists in the data (has been added through the Tahoe Dashboard), have certain components/templates display the translation text
- this addition should be backwards compatible. Meaning if the site data (JSON) for some reason is not in the new _translation enabled_ format, it should not break, nor display crazy mumbo jumbo but the data served

Just so it's clear, here's the old page structure:

```
...
"index": {
    "content": [
        ...
        {
            "element-type": "heading",
            "element-path":"page-builder/elements/_heading.html",
            "options":{
                "font-size":"font-size--48px",
                ...
                "text-content":"This is my text and my site is in just one language. Meh."
                ...
            }
        }
        ...
    ]
}
```

And here's the new page structure that's already getting generated by some sweet magic in Tahoe (_there's a PR there too!_):
```
...
"index": {
    "content": [
        ...
        {
            "element-type": "heading",
            "element-path":"page-builder/elements/_heading.html",
            "options":{
                "font-size":"font-size--48px",
                ...
                "text-content":{
                    "en":"Hey, this title is in english!"
                    "fr":"Hey, le text c'est Francais! (I know zero French)"
                    ...
                ...
            }
        }
        ...
    ]
}
```

### How do we achieve the goals described above?

1. First we make theme-variables aware of two things: what's the **default site language** (set through Tahoe Dashboard and stored in site config JSON) and what's the **detected language** by Djago (aka _current language_)
2. We create two functions: **return_translation** and **return_translation_to_var**. Both take a **translations_object** as an argument, and the first one is called and returns to a template, while the second one is used in theme-variables to get a translation value and store it in a variable/object (for example for certificate settings), that another template will then use (and therefore we don't need to modify any additional templates for this).
3. The two functions function in the same manner:
- take a translation_object
- if it's a dictionary, return the value of that dictionary for the key that is the current_language. If that key doesn't exist (aka there is no translation in the translation_object for that language), try to fetch a translation in the site default language. If even that key doesn't exist (for any reason), it falls back to just returning an empty string. No breakages.
- if it isn't a dictionary, that means the site data (or the data for the component that called the function) isn't in the new translation-enabled format. Then the function will just return the entire value, since it is the old-school-pre-localisation-work string.
4. We hook up the first function to our page elements templates (Heading text, CTA button, etc.). We hook the second function to various settings in theme-variables that are translatable and that get passed to templates (for example footer copyright text that gets passed to the footer template).
5. WOAH! SUPER SHINY TRANSLATED STUFF! MUCH AWESOME SO WOW!

_Note:_
You may at this point be asking yourself: "But Matej! If you're passing the values form theme-variables already translated for some stuff (such as footer template), why aren't you doing so for everything? Why the two functions you crazy but weirdly mostly efficient old bastard?"
Well I'm glad you asked! That's because the structure for footer, copyright etc. is _fixed_. We know where the translated fields are and they always are there. But you cannot do that with the dynamically populated page structure. Hence it's more logical, safer and overall less hair-pulling to just call for a translation from the component that's actually doing the rendering, such as "Paragraph text" component/template.