### PR TITLE
add custom additional meta tags to lms site

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -24,7 +24,7 @@
 % endif
 % if get_global_settings().get('custom_site_meta_tags'):
   % for meta_tag in get_global_settings().get('custom_site_meta_tags'):
-    % if meta_tag['tagName']:
+    % if meta_tag.get('tagName'):
       <meta name="${meta_tag['tagName']}" content="${meta_tag['tagContent']}" />
     % elif meta_tag['tagProperty']:
       <meta property="${meta_tag['tagProperty']}" content="${meta_tag['tagContent']}" />

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -26,7 +26,7 @@
   % for meta_tag in get_global_settings().get('custom_site_meta_tags'):
     % if meta_tag.get('tagName'):
       <meta name="${meta_tag['tagName']}" content="${meta_tag['tagContent']}" />
-    % elif meta_tag['tagProperty']:
+    % elif meta_tag.get('tagProperty'):
       <meta property="${meta_tag['tagProperty']}" content="${meta_tag['tagContent']}" />
     % endif
   % endfor

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -22,6 +22,15 @@
 % if apple_app_id:
   <meta name="apple-itunes-app" content="app-id=${get_global_settings()['apple_app_id']}">
 % endif
+% if get_global_settings().get('custom_site_meta_tags'):
+  % for meta_tag in get_global_settings().get('custom_site_meta_tags'):
+    % if meta_tag['tagName']:
+      <meta name="${meta_tag['tagName']}" content="${meta_tag['tagContent']}" />
+    % elif meta_tag['tagProperty']:
+      <meta property="${meta_tag['tagProperty']}" content="${meta_tag['tagContent']}" />
+    % endif
+  % endfor
+% endif
 
 <%include file="partials/analytics.html" />
 

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -41,6 +41,7 @@
     'appsembler_ga_code': "UA-18398802-14", ## need to enter correct one
     'client_ga_code': get_value('client_ga_code', ""),
     'allow_search_engine_indexing': get_value('allow_search_engine_indexing', True),
+    'custom_site_meta_tags': get_value('site_seo_tags', []),
   }
   %>
 </%def>


### PR DESCRIPTION
This addition is part of the new feature that allows users to add new meta tags. Theme variables gets the meta tags from the site configuration, then the head-extra template iterates over them and adds them to the site head area. Easy peasy :)