### PR TITLE
Cleanup: Simplify translating variables and vars

### DIFF
--- a/lms/templates/design-templates/footer/_footer-appsembler-01.html
+++ b/lms/templates/design-templates/footer/_footer-appsembler-01.html
@@ -1,7 +1,7 @@
 <%page args="footer_links, footer_logo, footer_logo_alt_text, footer_copyright_text, display_edx_disclaimer, edx_disclaimer, display_poweredby" />
 <%namespace file='/theme-variables.html' import="get_footer_settings" />
 <%namespace name='static' file='/static_content.html'/>
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 <%! from django.utils.translation import ugettext as _ %>
 
 <footer class="a--footer">
@@ -29,7 +29,7 @@
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${return_translation(item['link_title'])}</a>
+              >${item['link_title'] | translate}</a>
             </li>
             % endfor
           </ul>

--- a/lms/templates/design-templates/header/_header-appsembler-01.html
+++ b/lms/templates/design-templates/header/_header-appsembler-01.html
@@ -3,7 +3,7 @@
 from django.utils.translation import ugettext as _
 %>
 <%namespace name='static' file='/static_content.html'/>
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 ## mako
 
 <!-- top navigation -->
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${return_translation(item['link_title'])}</a>
+              >${item['link_title'] | translate}</a>
             </li>
             % endfor
           </ul>
@@ -65,7 +65,7 @@ from django.utils.translation import ugettext as _
                     % if item['open_in_new_tab']:
                       target="_blank"
                     % endif
-                    >${return_translation(item['link_title'])}</a>
+                    >${item['link_title'] | translate}</a>
                   </li>
                 % endfor
                 <% first_slideout_item = False %>

--- a/lms/templates/design-templates/header/_header-appsembler-02.html
+++ b/lms/templates/design-templates/header/_header-appsembler-02.html
@@ -3,7 +3,7 @@
 from django.utils.translation import ugettext as _
 %>
 <%namespace name='static' file='/static_content.html'/>
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 ## mako
 
 <!-- top navigation -->
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${return_translation(item['link_title'])}</a>
+              >${item['link_title'] | translate}</a>
             </li>
             % endfor
           </ul>
@@ -63,7 +63,7 @@ from django.utils.translation import ugettext as _
                     % if item['open_in_new_tab']:
                       target="_blank"
                     % endif
-                    >${return_translation(item['link_title'])}</a>
+                    >${item['link_title'] | translate}</a>
                   </li>
                 % endfor
                 <% first_slideout_item = False %>

--- a/lms/templates/page-builder/elements/_content-block.html
+++ b/lms/templates/page-builder/elements/_content-block.html
@@ -1,7 +1,7 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 <div class="amc--element--content-block amc--style-classes ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}">
-  ${return_translation(options['content'])}
+  ${options['content'] | translate}
 </div>

--- a/lms/templates/page-builder/elements/_cta-button.html
+++ b/lms/templates/page-builder/elements/_cta-button.html
@@ -1,6 +1,6 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 <%
   element_style = ""
@@ -8,5 +8,5 @@
 %>
 
 <a class="amc--element--cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="${options['url']}">
-  ${return_translation(options['text-content'])}
+  ${options['text-content'] | translate}
 </a>

--- a/lms/templates/page-builder/elements/_heading.html
+++ b/lms/templates/page-builder/elements/_heading.html
@@ -1,6 +1,6 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 <%! from django.utils import translation %>
 
 <%
@@ -9,5 +9,5 @@
 %>
 
 <h2 class="amc--element--heading amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
-  ${return_translation(options['text-content'])}
+  ${options['text-content'] | translate}
 </h2>

--- a/lms/templates/page-builder/elements/_image-graphic.html
+++ b/lms/templates/page-builder/elements/_image-graphic.html
@@ -1,11 +1,11 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 % if options['link-url']:
   <a class="amc--element--image-graphic__link-wrapper" href="${options['link-url']}">
 % endif
-  <img src="${options['image-file']}" role="presentation" alt="${return_translation(options['image-alt-text'])}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
+  <img src="${options['image-file']}" role="presentation" alt="${options['image-alt-text'] | translate}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
 % if options['link-url']:
   </a>
 % endif

--- a/lms/templates/page-builder/elements/_paragraph.html
+++ b/lms/templates/page-builder/elements/_paragraph.html
@@ -1,7 +1,7 @@
 ## mako
 <%page args="options" />
 <%! from django.utils import translation %>
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 <%
   element_style = ""
@@ -10,5 +10,5 @@
 %>
 
 <p class="amc--element--paragraph-text amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
-  ${return_translation(options['text-content'])}
+  ${options['text-content'] | translate}
 </p>

--- a/lms/templates/page-builder/elements/_popup-video-cta-button.html
+++ b/lms/templates/page-builder/elements/_popup-video-cta-button.html
@@ -1,6 +1,6 @@
 ## mako
 <%page args="options" />
-<%namespace file='/theme-variables.html' import="return_translation" />
+<%namespace file='/theme-variables.html' import="translate" />
 
 <%
   element_style = ""
@@ -8,7 +8,7 @@
 %>
 
 <a class="amc--element--popup-video-cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="#" data-toggle="modal" data-target="#${options['youtube-video-id']}Modal">
-  ${return_translation(options['text-content'])}
+  ${options['text-content'] | translate}
 </a>
 
 <div class="modal a--modal a--modal__video fade" id="${options['youtube-video-id']}Modal" tabindex="-1" role="dialog" aria-labelledby="${options['youtube-video-id']}Modal">

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -9,29 +9,21 @@
 <%! from django.utils import translation %>
 
 
-
 <%!
   theme_name = "eucalyptus-theme-codebase"
   current_language = translation.get_language()
   site_default_language = get_value('site_default_language', "en")
 %>
 
-<%def name="return_translation(translations_object)">
-  % if (isinstance(translations_object, dict)):
-    ${translations_object.get(current_language, translations_object.get(site_default_language, ""))}
-  % else:
-    ${translations_object}
-  % endif
-</%def>
 
-<%def name="return_translation_to_var(translations_object)">
+<%def name="translate(translations_object)">
   % if (isinstance(translations_object, dict)):
     <%
-      return "%s" % (translations_object.get(current_language, translations_object.get(site_default_language, "")))
+      return str(translations_object.get(current_language, translations_object.get(site_default_language, "")))
     %>
   % else:
     <%
-      return "%s" % (translations_object)
+      return str(translations_object)
     %>
   % endif
 </%def>
@@ -140,9 +132,9 @@
     footer_options = get_current_site_configuration().page_elements.get('footer', {}).get('options', {})
     return {
       'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
-      'footer_copyright_text' : return_translation_to_var(footer_options.get('footer_copyright_text', '©' + date.today().strftime('%Y') + ' Company Name. All rights reserved.')),  ## leave value empty if you don't want it displayed.
+      'footer_copyright_text' : translate(footer_options.get('footer_copyright_text', '©' + date.today().strftime('%Y') + ' Company Name. All rights reserved.')),  ## leave value empty if you don't want it displayed.
       'display_edx_disclaimer' : footer_options.get('display_edx_disclaimer', True), ## bool value required
-      'edx_disclaimer' : return_translation_to_var(footer_options.get('edx_disclaimer', 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')), ## leave value empty if you don't want it displayed.
+      'edx_disclaimer' : translate(footer_options.get('edx_disclaimer', 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')), ## leave value empty if you don't want it displayed.
       'display_poweredby' : footer_options.get('display_poweredby', True), ## bool value required
       'display_app_link' : footer_options.get('display_app_link', False),
       'app_url' : footer_options.get('app_url', '')
@@ -333,21 +325,21 @@
     'header_logo_width': get_value('certificates', {}).get('header_logo_width', '240px'),
     'cert_logo': get_value('certificates', {}).get('cert_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
     'logo_width': get_value('certificates', {}).get('cert_logo_width', '160px'),
-    'platform_name': return_translation_to_var(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', 'Platform Name'))),
-    'header_text': return_translation_to_var(get_value('certificates', {}).get('header_text', 'Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
-    'short_platform_description': return_translation_to_var(get_value('certificates', {}).get('short_platform_description', '')),
-    'we_hereby_text': return_translation_to_var(get_value('certificates', {}).get('we_hereby_text', 'We hereby certify that:')),
-    'successfully_completed_text': return_translation_to_var(get_value('certificates', {}).get('successfully_completed_text', "successfully completed, received a passing grade, and was awarded this platforms' Honor Code Certificate of Completion in:")),
-    'optional_cert_text': return_translation_to_var(get_value('certificates', {}).get('optional_cert_text', '')),
-    'footer_about_platform_text': return_translation_to_var(get_value('certificates', {}).get('footer_about_platform_text', 'Our platform offers interactive online classes and MOOCs.')),
+    'platform_name': translate(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', 'Platform Name'))),
+    'header_text': translate(get_value('certificates', {}).get('header_text', 'Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
+    'short_platform_description': translate(get_value('certificates', {}).get('short_platform_description', '')),
+    'we_hereby_text': translate(get_value('certificates', {}).get('we_hereby_text', 'We hereby certify that:')),
+    'successfully_completed_text': translate(get_value('certificates', {}).get('successfully_completed_text', "successfully completed, received a passing grade, and was awarded this platforms' Honor Code Certificate of Completion in:")),
+    'optional_cert_text': translate(get_value('certificates', {}).get('optional_cert_text', '')),
+    'footer_about_platform_text': translate(get_value('certificates', {}).get('footer_about_platform_text', 'Our platform offers interactive online classes and MOOCs.')),
     'footer_about_platform_url': get_value('certificates', {}).get('footer_about_platform_url', '#'),
-    'footer_about_accomplishments_text': return_translation_to_var(get_value('certificates', {}).get('footer_about_accomplishments_text', "Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.")),
-    'footer_copyright_text': return_translation_to_var(get_value('certificates', {}).get('footer_copyright_text', "")),
+    'footer_about_accomplishments_text': translate(get_value('certificates', {}).get('footer_about_accomplishments_text', "Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.")),
+    'footer_copyright_text': translate(get_value('certificates', {}).get('footer_copyright_text', "")),
     'footer_tos_url': get_value('certificates', {}).get('footer_tos_url', "#"),
     'footer_privacy_url': get_value('certificates', {}).get('footer_privacy_url', "#"),
     'accomplishment_icon': get_value('certificates', {}).get('cert_accomplishment_icon', ''),
     'accomplishment_icon_width': get_value('certificates', {}).get('cert_accomplishment_icon_width', '60px'),
-    'certificate_custom_org_name': return_translation_to_var(get_value('certificates', {}).get('certificate_custom_org_name', "")),
+    'certificate_custom_org_name': translate(get_value('certificates', {}).get('certificate_custom_org_name', "")),
   }
   %>
 </%def>


### PR DESCRIPTION
Follow up on: https://github.com/appsembler/edx-theme-customers/pull/43

Mostly the same functionality. But using one function for both variables and template prints.

The filter syntaxt `${item['link_title'] | translate}` should work, but I have no way to test it!

Instead, we can use `${translate(item['link_title'])}`, which is exactly the same, but less fancy.

Please check it out and let me know.