### PR TITLE
set client ga code to empty, add custom client GTM code

### DIFF
--- a/lms/templates/theme-google-analytics.html
+++ b/lms/templates/theme-google-analytics.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-29244552-16"></script>
+<script>
+ window.dataLayer = window.dataLayer || [];
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+
+ gtag('config', 'UA-29244552-16');
+</script>

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -30,7 +30,7 @@
     'course-catalogue_enabled': True,
     'enable_course_catalogue_for_non-auth_users': True,
     'appsembler_ga_code': "UA-18398802-14", ## need to enter correct one
-    'client_ga_code': "UA-29244552-16", ## Using JFrog's Google Analytics account
+    'client_ga_code': "", ## Using JFrog's Google Analytics account
     'allow_search_engine_indexing': True,
     'small_screen_optimized_courseware': False,
     'enable_legacy_courseware_nav': True,


### PR DESCRIPTION
Removed the ID from client_ga_code variable, since it is the ID for Google Tag Manager, not Google Analytics. Also overriding the theme-google-analytics.html template and adding Google Tag Manager code supplied by the customer into it.