### PR TITLE
Refactor `translate` calls and use `force_text`

### DIFF
--- a/lms/templates/design-templates/footer/_footer-appsembler-01.html
+++ b/lms/templates/design-templates/footer/_footer-appsembler-01.html
@@ -29,7 +29,7 @@
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${item['link_title'] | translate}</a>
+              >${translate(item['link_title'])}</a>
             </li>
             % endfor
           </ul>

--- a/lms/templates/design-templates/header/_header-appsembler-01.html
+++ b/lms/templates/design-templates/header/_header-appsembler-01.html
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${item['link_title'] | translate}</a>
+              >${translate(item['link_title'])}</a>
             </li>
             % endfor
           </ul>
@@ -65,7 +65,7 @@ from django.utils.translation import ugettext as _
                     % if item['open_in_new_tab']:
                       target="_blank"
                     % endif
-                    >${item['link_title'] | translate}</a>
+                    >${translate(item['link_title'])}</a>
                   </li>
                 % endfor
                 <% first_slideout_item = False %>

--- a/lms/templates/design-templates/header/_header-appsembler-02.html
+++ b/lms/templates/design-templates/header/_header-appsembler-02.html
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
               % if item['open_in_new_tab']:
                 target="_blank"
               % endif
-              >${item['link_title'] | translate}</a>
+              >${translate(item['link_title'])}</a>
             </li>
             % endfor
           </ul>
@@ -63,7 +63,7 @@ from django.utils.translation import ugettext as _
                     % if item['open_in_new_tab']:
                       target="_blank"
                     % endif
-                    >${item['link_title'] | translate}</a>
+                    >${translate(item['link_title'])}</a>
                   </li>
                 % endfor
                 <% first_slideout_item = False %>

--- a/lms/templates/page-builder/elements/_content-block.html
+++ b/lms/templates/page-builder/elements/_content-block.html
@@ -3,5 +3,5 @@
 <%namespace file='/theme-variables.html' import="translate" />
 
 <div class="amc--element--content-block amc--style-classes ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}">
-  ${options['content'] | translate}
+  ${translate(options['content'])}
 </div>

--- a/lms/templates/page-builder/elements/_cta-button.html
+++ b/lms/templates/page-builder/elements/_cta-button.html
@@ -8,5 +8,5 @@
 %>
 
 <a class="amc--element--cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="${options['url']}">
-  ${options['text-content'] | translate}
+  ${translate(options['text-content'])}
 </a>

--- a/lms/templates/page-builder/elements/_heading.html
+++ b/lms/templates/page-builder/elements/_heading.html
@@ -9,5 +9,5 @@
 %>
 
 <h2 class="amc--element--heading amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
-  ${options['text-content'] | translate}
+  ${translate(options['text-content'])}
 </h2>

--- a/lms/templates/page-builder/elements/_image-graphic.html
+++ b/lms/templates/page-builder/elements/_image-graphic.html
@@ -5,7 +5,7 @@
 % if options['link-url']:
   <a class="amc--element--image-graphic__link-wrapper" href="${options['link-url']}">
 % endif
-  <img src="${options['image-file']}" role="presentation" alt="${options['image-alt-text'] | translate}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
+  <img src="${options['image-file']}" role="presentation" alt="${translate(options['image-alt-text'])}" class="amc--element--image-graphic amc--style-classes ${options['image-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" />
 % if options['link-url']:
   </a>
 % endif

--- a/lms/templates/page-builder/elements/_paragraph.html
+++ b/lms/templates/page-builder/elements/_paragraph.html
@@ -10,5 +10,5 @@
 %>
 
 <p class="amc--element--paragraph-text amc--style-classes ${options['font-size']} ${options['font-family']} ${options['text-alignment']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']}" style="${element_style}">
-  ${options['text-content'] | translate}
+  ${translate(options['text-content'])}
 </p>

--- a/lms/templates/page-builder/elements/_popup-video-cta-button.html
+++ b/lms/templates/page-builder/elements/_popup-video-cta-button.html
@@ -8,7 +8,7 @@
 %>
 
 <a class="amc--element--popup-video-cta-button amc--style-classes ${options['font-size']} ${options['font-family']} ${options['border-width']} ${options['margin-top']} ${options['margin-right']} ${options['margin-bottom']} ${options['margin-left']} ${options['padding-top']} ${options['padding-right']} ${options['padding-bottom']} ${options['padding-left']}" style="${element_style}" href="#" data-toggle="modal" data-target="#${options['youtube-video-id']}Modal">
-  ${options['text-content'] | translate}
+  ${translate(options['text-content'])}
 </a>
 
 <div class="modal a--modal a--modal__video fade" id="${options['youtube-video-id']}Modal" tabindex="-1" role="dialog" aria-labelledby="${options['youtube-video-id']}Modal">

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -4,9 +4,10 @@
 <%! from openedx.core.djangoapps.site_configuration.helpers import get_current_site_configuration, get_value %>
 <%! from openedx.core.djangoapps.site_configuration.models import SiteConfiguration %>
 <%! from django.contrib.staticfiles.templatetags.staticfiles import static %>
+<%! from django.utils.encoding import force_text %>
+<%! from django.utils import translation %>
 <%! from django.utils.translation import ugettext as _ %>
 <%! from datetime import date %>
-<%! from django.utils import translation %>
 
 
 <%!
@@ -19,11 +20,11 @@
 <%def name="translate(translations_object)">
   % if (isinstance(translations_object, dict)):
     <%
-      return str(translations_object.get(current_language, translations_object.get(site_default_language, "")))
+      return force_text(translations_object.get(current_language, translations_object.get(site_default_language, "")))
     %>
   % else:
     <%
-      return str(translations_object)
+      return force_text(translations_object)
     %>
   % endif
 </%def>


### PR DESCRIPTION
 - Looks like the fancy "filter" don't work, I've reverted to normal function calls and now it actually translates.
 - Using `force_text` instead of `str` is better, since it can handle both `unicode` and `str` correctly without throwing nasty encoding exceptions. It shouldn't have performance impact, as far as I can remember last time I used at edX it was accepted.

### English
<kbd>![image](https://user-images.githubusercontent.com/645156/49723614-e77b7f80-fc6f-11e8-8eff-5814e4b096fa.png)</kbd>


### Arabic
<kbd>![image](https://user-images.githubusercontent.com/645156/49723365-4f7d9600-fc6f-11e8-9611-348516b3d14e.png)</kbd>


