### PR TITLE
Fix the header logo URL and screen reader caption

### DIFF
--- a/lms/templates/certificates/_accomplishment-header.html
+++ b/lms/templates/certificates/_accomplishment-header.html
@@ -6,10 +6,10 @@
 
     <header class="header-app" role="banner">
         <h1 class="header-app-title">
-            <a class="logo" href="${logo_url}" style="width: auto;">
+            <a class="logo" href="${request.site}" style="width: auto;">
                 <img class="a--accomplishment--header-logo" style="width: ${get_certificates_settings()['header_logo_width']}; height: auto;" src="${get_certificates_settings()['header_logo']}" alt="${get_certificates_settings()['platform_name']}" />
             </a>
-            <span class="sr-only">${logo_subtitle}</span>
+            <span class="sr-only">${get_certificates_settings()['platform_name']}</span>
         </h1>
     </header>
 


### PR DESCRIPTION
This fixes the issue where our Tahoe customers' certs had the header link lead to `www.example.com`. In retrospective, that was clearly wrong as in best case only one customer could have the domain www.example.com. And why would someone even have it? It is quite a silly domain. 
Btw today I learned that domains such as `example.com` and `example.org` are actually reserved for documentation purposes. How thoughtful.

Anyway, fixed.