### PR TITLE
AMC: Remove the forgot password from the Studio login

### DIFF
--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -33,7 +33,6 @@ from openedx.core.djangolib.js_utils import js_escaped_string
             <li class="field text required" id="field-password">
               <label for="password">${_("Password")}</label>
               <input id="password" type="password" name="password" />
-              <a href="${forgot_password_link}" class="action action-forgotpassword">${_("Forgot password?")}</a>
             </li>
           </ol>
         </fieldset>


### PR DESCRIPTION
Because Tahoe users come to Studio without much of clue who they are so, it's hard to know which is the correct LMS to redirect to.

So `'forgot_password_link': "//{base}/login#forgot-password-modal".format(base=settings.LMS_BASE),` doesn't really make sense on Tahoe as `cms/djangoapps/contentstore/views/public.py` sets it.

The better solution is to have a per-customer URL:

```
studio.university.redislabs.com
university.redislabs.com
preview.university.redislabs.com
```

It's possible, but we just didn't do it. I've added an [idea to Prod Pad](https://app.prodpad.com/ideas/50e9bbe0-2f82-11e9-95e8-91651bd2ac15/canvas).


### Screenshot
![image](https://user-images.githubusercontent.com/645156/52708632-4ec8ef00-2f93-11e9-84b8-ba7c8f87b244.png)
