### PR TITLE
Feature/custom sass html

### DIFF
--- a/lms/static/sass/_customer-sass-input.scss
+++ b/lms/static/sass/_customer-sass-input.scss
@@ -1,0 +1,1 @@
+// placeholder for customer's custom SASS

--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -7,3 +7,5 @@
     display: none;
   }
 }
+
+@import "customer-sass-input";

--- a/lms/templates/page-builder/elements/_html-block.html
+++ b/lms/templates/page-builder/elements/_html-block.html
@@ -1,0 +1,7 @@
+## mako
+<%page args="options" />
+<%namespace file='/theme-variables.html' import="translate" />
+
+<div class="amc--element--content-block amc--style-classes">
+  ${translate(options['content'])}
+</div>


### PR DESCRIPTION
This addition is needed for our custom HTML/CSS feature in AMC:

- we add another customer specific piece of sass that is just an empty file included. On LMS backend side, when the SASS is being (re)compiled, upon hitting the import of `customer-sass-input`, the compiler will replace the contents of that (empty) file with the contents of the value field in the site configuration that contains the custom CSS that the customer has entered. It is included at the end of `_customer-specific.scss` SASS file. This is because we want it to be compiled into the very end of the stylesheet, allowing customer overrides.
- we add a HTML block template. Just a simple template with no styling that will contain some custom HTML added by the customer.