### PR TITLE
Bring back the tooltips in course top nav

### DIFF
--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -74,11 +74,6 @@ to match styling of content imported from texasgateway.org
   max-width: 700px;
 }
 
-.xblock-student_view .sequence-list-wrapper {
-  overflow-x: scroll;
-  overflow-y: hidden;
-}
-
 
 /* Hide View Unit in Studio link if not course staff
 (don't show to Instructors as is normal)


### PR DESCRIPTION
This PR solve the issue of hidden course units tooltip