### PR TITLE
Tahoe Hawthorn: Cherry pick 'hotfix for “hide linked accounts tab”'

### DIFF
--- a/lms/static/sass/base/_branding-basics.scss
+++ b/lms/static/sass/base/_branding-basics.scss
@@ -159,3 +159,5 @@ $courseware-content-bottom-nav-width: 30%;
 $courseware-link-hover: "expanding-underline";  // can be "hover-pop", "expanding-underline", "brand-color" or "opacity"
 $courseware-content-font-size: 16px;
 $courseware-content-line-height: 20px;
+
+$hide-linked-accounts-tab: false;


### PR DESCRIPTION
Trial process is broken in Hawthorn because:

 - `edx-theme-customers:hawthron/amc` didn't have the commit bd6b97668b7ef9c47d9af39e85f0ebcc21231af4 
- But `edx-theme-codebase:hawthorn/master` expected that commit as of https://github.com/appsembler/edx-theme-codebase/pull/6/commits/e3986828c32422e7923e65da2a701b6b87c7486c 

Which is odd, but this pull request fixes it.

See the related platform pull request: https://github.com/appsembler/edx-platform/pull/342