### PR TITLE
add embargo function to theme variables

### DIFF
--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -318,6 +318,14 @@
   %>
 </%def>
 
+## embargo page content
+
+<%def name="get_embargo_content()">
+  <%
+    return get_current_site_configuration().page_elements.get('embargo', {}).get('content', [])
+  %>
+</%def>
+
 ## certs settings
 
 <%def name="get_certificates_settings()">


### PR DESCRIPTION
We had this function missing, which is why the embargo page was giving an error.