### PR TITLE
Remove extra spaces in "translate" function + Fix theme name

### DIFF
--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -11,7 +11,7 @@
 
 
 <%!
-  theme_name = "eucalyptus-theme-codebase"
+  theme_name = "edx-theme-codebase"
 %>
 
 

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -15,19 +15,15 @@
 %>
 
 
-<%def name="translate(translations_object)">
-  % if (isinstance(translations_object, dict)):
-    <%
-      current_language = translation.get_language()
-      language_code = get_value('LANGUAGE_CODE', 'en')
-      return force_text(translations_object.get(current_language, translations_object.get(language_code, '')))
-    %>
-  % else:
-    <%
-      return force_text(translations_object)
-    %>
-  % endif
-</%def>
+<%def name="translate(translations_object)"><%
+  if isinstance(translations_object, dict):
+    current_language = translation.get_language()
+    language_code = get_value('LANGUAGE_CODE', 'en')
+    return force_text(translations_object.get(current_language, translations_object.get(language_code, '')))
+  else:
+    return force_text(translations_object)
+  endif
+%></%def>
 
 
 


### PR DESCRIPTION
Simple one, the Mako template prints whatever you put between `<%def name="translate(translations_object)">` and `<%`, compressing the spaces fixes the issue ... hopefully!