### PR TITLE
Hack: Hide the Poll XBlock export buttons

### DIFF
--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -16,4 +16,9 @@
   }
 }
 
+// Patch: Hide the export buttons on Tahoe Hawthorn temporally
+.poll-block .export-results-button-wrapper {
+  visibility: hidden;
+}
+
 @import "customer-sass-input";


### PR DESCRIPTION
It's not working, so let's hide it for now.

@grozdanowski I've used `visibility: hidden` to avoid having to fix floats issues.