### PR TITLE
connect the feature flag for courseware left-nav to amc

### DIFF
--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -55,6 +55,7 @@
     'allow_search_engine_indexing': get_value('allow_search_engine_indexing', True),
     'custom_site_meta_tags': get_value('site_seo_tags', []),
     'combine_privacy_and_tos': get_value('combine_privacy_and_tos', False),
+    'enable_legacy_courseware_nav': get_value('enable_legacy_courseware_nav', True),
   }
   %>
 </%def>


### PR DESCRIPTION
Simple - we add a setting to enable/disable the legacy left-side courseware nav. This PR adds the tag into theme-variables and hooks it up to AMC. Fallback for the setting is that the legacy nav is enabled.

AMC-side companion PR: https://github.com/appsembler/amc/pull/182

