### PR TITLE
fix the way how certs css is included for tahoe

### DIFF
--- a/lms/templates/certificates/accomplishment-base.html
+++ b/lms/templates/certificates/accomplishment-base.html
@@ -2,8 +2,9 @@
 <%namespace name='static' file='/static_content.html'/>
 <%namespace file='/theme-variables.html' import="get_global_settings, get_brand_favicon" />
 <%! from django.utils.translation import ugettext as _ %>
-<%! from openedx.core.djangoapps.site_configuration.helpers import get_current_site_configuration %>
+<%! from openedx.core.djangoapps.site_configuration.helpers import get_current_site_configuration, get_value %>
 <%! from django.contrib.staticfiles.templatetags.staticfiles import static as djstatic %>
+<% style_overrides_file = get_value('css_overrides_file') %>
 
 <%
 # set doc language direction
@@ -27,11 +28,17 @@ course_mode_class = course_mode if course_mode else ''
 
     <%static:css group='style-certificates'/>
 
-    % if site_configuration:
-      <link rel="stylesheet" type="text/css" href="${site_configuration.get_css_url()}" />
+    % if style_overrides_file:
+      ## TODO: `USE_S3_FOR_CUSTOMER_THEMES` should be deprecated. See: github.com/appsembler/edx-platform/issues/341
+      % if settings.USE_S3_FOR_CUSTOMER_THEMES:
+        <link rel="stylesheet" type="text/css" href="${get_current_site_configuration().get_css_url()}" />
+      % else:
+        <link rel="stylesheet" type="text/css" href="${djstatic(style_overrides_file)}" />
+      % endif
     % else:
       <link rel="stylesheet" type="text/css" href="${djstatic('css/main.css')}">
     % endif
+    
     <link href="${get_global_settings()['fonts_url']}" rel="stylesheet" />
 </head>
 


### PR DESCRIPTION
Pretty straightforward. Need to be included the same way we do in main template for the LMS. Copied from there, adjusted a bit. Now works fine and dandy from what I see.