### PR TITLE
Change Help links in Tahoe Studio

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -222,7 +222,7 @@
         <h2 class="sr">${_("Account Navigation")}</h2>
         <ol>
           <li class="nav-item nav-account-help">
-            <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" target="_blank">${_("Help")}</a></span></h3>
+            <h3 class="title"><span class="label"><a href="https://help.appsembler.com/" title="${_('Appsembler Online Knowledgebase')}" target="_blank">${_("Help")}</a></span></h3>
           </li>
           <li class="nav-item nav-account-user">
             <h3 class="title"><span class="label"><span class="label-prefix sr">${_("Currently signed in as:")}</span><span class="account-username" title="${ user.username }">${ user.username }</span></span> <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span></h3>
@@ -248,7 +248,7 @@
         <h2 class="sr">${_("Account Navigation")}</h2>
         <ol>
           <li class="nav-item nav-not-signedin-help">
-            <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" target="_blank">${_("Help")}</a>
+            <a href="https://help.appsembler.com/" title="${_('Appsembler Online Knowledgebase')}" target="_blank">${_("Help")}</a>
           </li>
           ## Appsembler: Disabling signup in Studio
           % if False and static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):


### PR DESCRIPTION
Change the Help link in header nav to lead to our knowledge base.