### PR TITLE
Remove obsolete help links

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -168,9 +168,6 @@ from openedx.core.release import RELEASE_LINE
         </div>
       </main>
 
-      % if user.is_authenticated:
-        <%include file="/widgets/sock.html" args="online_help_token=online_help_token" />
-      % endif
       <%include file="/widgets/footer.html" />
 
       <div id="page-notification"></div>

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -522,17 +522,6 @@ from openedx.core.djangolib.js_utils import (
 
     </article>
     <aside class="content-supplementary" role="complementary">
-      <div class="bit">
-        <h3 class="title title-3">${_('New to {studio_name}?').format(studio_name=settings.STUDIO_NAME)}</h3>
-        <p>${_('Click Help in the upper-right corner to get more information about the {studio_name} page you are viewing. You can also use the links at the bottom of the page to access our continually updated documentation and other {studio_name} resources.').format(studio_name=settings.STUDIO_SHORT_NAME)}</p>
-
-        <ol class="list-actions">
-          <li class="action-item">
-
-            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank">${_("Getting Started with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
-          </li>
-        </ol>
-      </div>
 
       % if course_creator_status=='disallowed_for_this_site' and settings.FEATURES.get('STUDIO_REQUEST_EMAIL',''):
       <div class="bit">


### PR DESCRIPTION
Remove the bottom drawer with help links and the sidebar in Studio that lead to default Open edX help docs.