### PR TITLE
Fallback to gettext if amc admin did not provide translations

### DIFF
--- a/lms/templates/design-templates/pages/course-about/_course-about-01.html
+++ b/lms/templates/design-templates/pages/course-about/_course-about-01.html
@@ -2,7 +2,7 @@
 <%namespace file='/theme-variables.html' import="translate" />
 
 <%!
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 %>
 
 <%page args="template_settings, course_vars" />

--- a/lms/templates/design-templates/pages/course-about/_course-about-01.html
+++ b/lms/templates/design-templates/pages/course-about/_course-about-01.html
@@ -10,15 +10,15 @@ from django.utils.translation import ugettext as _
 <%
   course_image = course_vars['course_image']
 
-  courseware_button_already_enrolled_text = translate(template_settings.get('courseware-button-already-enrolled-text', _("You are enrolled in this course")))
-  courseware_button_view_courseware_text = translate(template_settings.get('courseware-button-view-courseware-text', _("View Course")))
-  courseware_button_in_cart_text = translate(template_settings.get('courseware-button-in-cart-text', _("Course is in your cart.")))
-  courseware_button_course_full_text = translate(template_settings.get('courseware-button-course-full-text', _("Course is full")))
-  courseware_button_invitation_only_text = translate(template_settings.get('courseware-button-invitation-only-text', _("Enrollment in this course is by invitation only")))
-  courseware_button_enrollment_closed_text = translate(template_settings.get('courseware-button-enrollment-closed-text', _("Enrollment is Closed")))
-  courseware_button_add_to_cart_text = u"{text} {price}".format(text=translate(template_settings.get('courseware-button-add-to-cart-text', _("Add to Cart / Price: "))), price=course_vars['course_price'])
-  courseware_button_enroll_text = u"{text} {price}".format(text=translate(template_settings.get('courseware-button-enroll-text', _("Enroll in "))), price=course_vars['course_name'])
-  view_in_studio_button_text = translate(template_settings.get('view-in-studio-button-text', _("View About Page in studio")))
+  courseware_button_already_enrolled_text = translate(template_settings.get('courseware-button-already-enrolled-text'), default=_("You are enrolled in this course"))
+  courseware_button_view_courseware_text = translate(template_settings.get('courseware-button-view-courseware-text'), default=_("View Course"))
+  courseware_button_in_cart_text = translate(template_settings.get('courseware-button-in-cart-text'), default=_("Course is in your cart."))
+  courseware_button_course_full_text = translate(template_settings.get('courseware-button-course-full-text'), default=_("Course is full"))
+  courseware_button_invitation_only_text = translate(template_settings.get('courseware-button-invitation-only-text'), default=_("Enrollment in this course is by invitation only"))
+  courseware_button_enrollment_closed_text = translate(template_settings.get('courseware-button-enrollment-closed-text'), default=_("Enrollment is Closed"))
+  courseware_button_add_to_cart_text = u"{text} {price}".format(text=translate(template_settings.get('courseware-button-add-to-cart-text'), default=_("Add to Cart / Price: ")), price=course_vars['course_price'])
+  courseware_button_enroll_text = u"{text} {price}".format(text=translate(template_settings.get('courseware-button-enroll-text'), default=_("Enroll in ")), price=course_vars['course_name'])
+  view_in_studio_button_text = translate(template_settings.get('view-in-studio-button-text'), default=_("View About Page in studio"))
 %>
 
 <section class="a--course-about-01__header">

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -12,17 +12,24 @@
 
 <%!
   theme_name = "edx-theme-codebase"
+
+  def _translate(translations_object, default=''):
+    current_language = translation.get_language()
+    fallback_language = get_value('LANGUAGE_CODE', 'en')
+
+    if not translations_object:
+      return force_text(default)
+
+    if not isinstance(translations_object, dict):
+      translations_object = {fallback_language: translations_object}
+
+    default_text = default if default else translations_object.get(fallback_language, '')
+    return force_text(translations_object.get(current_language, default_text))
 %>
 
 
-<%def name="translate(translations_object)"><%
-  if isinstance(translations_object, dict):
-    current_language = translation.get_language()
-    language_code = get_value('LANGUAGE_CODE', 'en')
-    return force_text(translations_object.get(current_language, translations_object.get(language_code, '')))
-  else:
-    return force_text(translations_object)
-  endif
+<%def name="translate(translations_object, default='')"><%
+    return _translate(translations_object, default)
 %></%def>
 
 

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -6,7 +6,9 @@
 <%! from django.contrib.staticfiles.templatetags.staticfiles import static %>
 <%! from django.utils.encoding import force_text %>
 <%! from django.utils import translation %>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import ugettext, ugettext_lazy as _ %>
+<%! from django.utils import six %>
+<%! from django.utils.functional import lazy %>
 <%! from datetime import date %>
 
 
@@ -18,13 +20,13 @@
     fallback_language = get_value('LANGUAGE_CODE', 'en')
 
     if not translations_object:
-      return force_text(default)
+      return default
 
     if not isinstance(translations_object, dict):
       translations_object = {fallback_language: translations_object}
 
-    default_text = default if default else translations_object.get(fallback_language, '')
-    return force_text(translations_object.get(current_language, default_text))
+    default_text = default if default else force_text(translations_object.get(fallback_language, ''))
+    return force_text(translations_object.get(current_language)) or default_text
 %>
 
 
@@ -137,11 +139,20 @@
 <%def name="get_footer_settings()">
   <%
     footer_options = get_current_site_configuration().page_elements.get('footer', {}).get('options', {})
+
+    def _default_copy_right():
+      return ugettext('{copy_sign} {year} Company Name. All rights reserved.').format(
+        copy_sign='©',
+        year=date.today().strftime('%Y'),
+      )
+
+    default_copy_right = lazy(_default_copy_right, six.text_type)
+
     return {
       'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
-      'footer_copyright_text' : translate(footer_options.get('footer_copyright_text', '©' + date.today().strftime('%Y') + ' Company Name. All rights reserved.')),  ## leave value empty if you don't want it displayed.
+      'footer_copyright_text' : translate(footer_options.get('footer_copyright_text'), default=default_copyright()),
       'display_edx_disclaimer' : footer_options.get('display_edx_disclaimer', True), ## bool value required
-      'edx_disclaimer' : translate(footer_options.get('edx_disclaimer', 'edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')), ## leave value empty if you don't want it displayed.
+      'edx_disclaimer' : translate(footer_options.get('edx_disclaimer'), default=_('edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')),
       'display_poweredby' : footer_options.get('display_poweredby', True), ## bool value required
       'display_app_link' : footer_options.get('display_app_link', False),
       'app_url' : footer_options.get('app_url', '')
@@ -340,15 +351,15 @@
     'header_logo_width': get_value('certificates', {}).get('header_logo_width', '240px'),
     'cert_logo': get_value('certificates', {}).get('cert_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
     'logo_width': get_value('certificates', {}).get('cert_logo_width', '160px'),
-    'platform_name': translate(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', 'Platform Name'))),
-    'header_text': translate(get_value('certificates', {}).get('header_text', 'Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
+    'platform_name': translate(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', '')), default=_('Platform Name')),
+    'header_text': translate(get_value('certificates', {}).get('header_text', ''), default=_('Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
     'short_platform_description': translate(get_value('certificates', {}).get('short_platform_description', '')),
-    'we_hereby_text': translate(get_value('certificates', {}).get('we_hereby_text', 'We hereby certify that:')),
-    'successfully_completed_text': translate(get_value('certificates', {}).get('successfully_completed_text', "successfully completed, received a passing grade, and was awarded this platform's Honor Code Certificate of Completion in:")),
+    'we_hereby_text': translate(get_value('certificates', {}).get('we_hereby_text', ''), default=_('We hereby certify that:')),
+    'successfully_completed_text': translate(get_value('certificates', {}).get('successfully_completed_text', ''), default=_('successfully completed, received a passing grade, and was awarded this platform\'s Honor Code Certificate of Completion in:')),
     'optional_cert_text': translate(get_value('certificates', {}).get('optional_cert_text', '')),
-    'footer_about_platform_text': translate(get_value('certificates', {}).get('footer_about_platform_text', 'Our platform offers interactive online classes and MOOCs.')),
+    'footer_about_platform_text': translate(get_value('certificates', {}).get('footer_about_platform_text'), default=_('Our platform offers interactive online classes and MOOCs.')),
     'footer_about_platform_url': get_value('certificates', {}).get('footer_about_platform_url', '#'),
-    'footer_about_accomplishments_text': translate(get_value('certificates', {}).get('footer_about_accomplishments_text', "Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.")),
+    'footer_about_accomplishments_text': translate(get_value('certificates', {}).get('footer_about_accomplishments_text'), default=_('Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.')),
     'footer_copyright_text': translate(get_value('certificates', {}).get('footer_copyright_text', "")),
     'footer_tos_url': get_value('certificates', {}).get('footer_tos_url', "#"),
     'footer_privacy_url': get_value('certificates', {}).get('footer_privacy_url', "#"),


### PR DESCRIPTION
### Why
This is to avoid having each customer to translate the entire theme strings to their language.

### Use Cases
 - Customer want to customize the default language: Can be done, unchagned.
 - Customer want to cusomtize another language i.e. French: Can be done, unchanged.
 - Customer want to avoid the hussle and get localized strings in each language: Can be done, NEW.
 - Other combinations of customize/sane-default should be covered as well.
 
### Technical Change
`translate()` now accepts a `default` argument which is best to be a `ugettext()` result.


### Alternative Methods
This closes the other not optimal alternative #87 

### Screenshots

##### English

![image](https://user-images.githubusercontent.com/645156/62534144-1d99ef00-b851-11e9-9f87-3a834158932d.png)

##### French

![image](https://user-images.githubusercontent.com/645156/62534293-77021e00-b851-11e9-97a2-5c10eaf9051a.png)
