### PR TITLE
Fix limiting of number of courses in course listing

### DIFF
--- a/lms/templates/page-builder/elements/_courses-listing.html
+++ b/lms/templates/page-builder/elements/_courses-listing.html
@@ -7,7 +7,7 @@
 <section class="amc--element--courses-listing courses-listing ${options['tile-type']}--parent-element amc--style-classes ${options['text-alignment']}">
   % if not courses is UNDEFINED:
     % for course in courses:
-      % if not course_count == options['num-of-courses']:
+      % if course_count < int(options['num-of-courses']):
         <%include file="/design-templates/live-blocks/single-course/_${options['tile-type']}.html" args="course=course" />
         <% course_count = course_count + 1 %>
       % endif

--- a/lms/templates/page-builder/elements/_courses-listing.html
+++ b/lms/templates/page-builder/elements/_courses-listing.html
@@ -8,7 +8,6 @@
   % if not courses is UNDEFINED:
     % for course in courses:
       <%include file="/design-templates/live-blocks/single-course/_${options['tile-type']}.html" args="course=course" />
-        <% course_count = course_count + 1 %>
       % endif
     % endfor
   % endif

--- a/lms/templates/page-builder/elements/_courses-listing.html
+++ b/lms/templates/page-builder/elements/_courses-listing.html
@@ -6,7 +6,7 @@
 
 <section class="amc--element--courses-listing courses-listing ${options['tile-type']}--parent-element amc--style-classes ${options['text-alignment']}">
   % if not courses is UNDEFINED:
-    % for course in courses:
+    % for course in courses[:int(options['num-of-courses'])]:
       <%include file="/design-templates/live-blocks/single-course/_${options['tile-type']}.html" args="course=course" />
     % endfor
   % endif

--- a/lms/templates/page-builder/elements/_courses-listing.html
+++ b/lms/templates/page-builder/elements/_courses-listing.html
@@ -7,7 +7,7 @@
 <section class="amc--element--courses-listing courses-listing ${options['tile-type']}--parent-element amc--style-classes ${options['text-alignment']}">
   % if not courses is UNDEFINED:
     % for course in courses:
-        <%include file="/design-templates/live-blocks/single-course/_${options['tile-type']}.html" args="course=course" />
+      <%include file="/design-templates/live-blocks/single-course/_${options['tile-type']}.html" args="course=course" />
         <% course_count = course_count + 1 %>
       % endif
     % endfor

--- a/lms/templates/page-builder/elements/_courses-listing.html
+++ b/lms/templates/page-builder/elements/_courses-listing.html
@@ -7,7 +7,6 @@
 <section class="amc--element--courses-listing courses-listing ${options['tile-type']}--parent-element amc--style-classes ${options['text-alignment']}">
   % if not courses is UNDEFINED:
     % for course in courses:
-      % if course_count < int(options['num-of-courses']):
         <%include file="/design-templates/live-blocks/single-course/_${options['tile-type']}.html" args="course=course" />
         <% course_count = course_count + 1 %>
       % endif

--- a/lms/templates/page-builder/elements/_courses-listing.html
+++ b/lms/templates/page-builder/elements/_courses-listing.html
@@ -8,7 +8,6 @@
   % if not courses is UNDEFINED:
     % for course in courses:
       <%include file="/design-templates/live-blocks/single-course/_${options['tile-type']}.html" args="course=course" />
-      % endif
     % endfor
   % endif
 </section>


### PR DESCRIPTION
Bug report was:

"In Page editor, > Index Page, > Index Page Course Listing... there is the option to set  max number of courses displayed.  Even when defined, this setting is disregarded, and the LMS still displays ALL the courses (not the number specified)"

**Analysis/fix:**
I was an idiot. Comparing a string to an int. And even then the check not making sense.

![image](https://user-images.githubusercontent.com/10602234/62661811-862cbd00-b972-11e9-92e9-45bf7a5e8530.png)
