### PR TITLE
Remove exception because it never should fire

### DIFF
--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -21,8 +21,6 @@
     fallback_language = get_value('LANGUAGE_CODE', 'en')
 
     if not translations_object:
-      if not default:
-        raise Exception('translate: Please provide either the AMC-provided translation or the default fallback.')
       return default
 
     if isinstance(translations_object, (basestring, Promise)):


### PR DESCRIPTION
When we deployed the latest changes to how we handle translations, we had a 500 error. Exception was being raised.

The thing is that the exception that we remove in this PR should never fire. It fired because an empty string was passed to translate function, but this is a very possible situation (for example, our problem was that the customer set the image alt text to be empty).