### PR TITLE
Fix cert URL overflowing in mobile

### DIFF
--- a/lms/static/sass/certificates/_certificate-template-01.scss
+++ b/lms/static/sass/certificates/_certificate-template-01.scss
@@ -209,6 +209,7 @@
   a {
     color: #fff;
     font-weight: bolder;
+    word-break: break-word;
   }
 
   @media screen {


### PR DESCRIPTION
Stupid problem, simple CSS solution.

Before:
<img width="319" alt="Screenshot 2019-08-16 at 15 46 18" src="https://user-images.githubusercontent.com/10602234/63172205-716cbb00-c03d-11e9-850d-470806d6d4f4.png">

After:
<img width="318" alt="Screenshot 2019-08-16 at 15 46 31" src="https://user-images.githubusercontent.com/10602234/63172211-76316f00-c03d-11e9-84b7-dd3db3bf5335.png">
