### PR TITLE
Hide the Studio "Invite Student" `mailto` button, it's useless

### DIFF
--- a/cms/static/css/amc-specific.css
+++ b/cms/static/css/amc-specific.css
@@ -1,8 +1,12 @@
+@charset "UTF-8";
 .wrapper-header .branding a img {
   max-height: 48px; }
 
+body.view-settings .group-settings.basic .list-actions {
+  display: none; }
+
 .a--howitworks-intro {
-  padding: 10rem 0;
+  padding: 12rem 0;
   background: linear-gradient(90deg, #154d64, #231f26); }
   .a--howitworks-intro__container {
     padding: 3rem;
@@ -33,3 +37,41 @@
     .a--howitworks-intro__login-cta:hover, .a--howitworks-intro__login-cta:focus {
       color: #fff;
       opacity: 0.7; }
+
+.amc--notification__content {
+  max-width: 1280px;
+  min-width: 900px;
+  width: 100%;
+  padding: 2rem 1.5rem;
+  border-radius: 3rem;
+  margin-top: 1.5rem;
+  background-color: #fff;
+  box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.5);
+  border: 0.2rem solid #E4572E;
+  color: #1a1a1a;
+  font-size: 1.4rem; }
+
+.amc--notification--button {
+  padding: 0.7rem 2rem;
+  margin: 0.5rem;
+  border-radius: 3rem;
+  text-decoration: none; }
+  .amc--notification--button.primary-action  {
+    background-color: #0090c1;
+    border: 0.2rem solid #0090c1;
+    color: #fff; }
+  .amc--notification--button.secondary-action {
+    background: none;
+    border: 0.2rem solid #0090c1;
+    color: #0090c1; }
+
+.amc--notification--tier-expiration {
+  display: flex;
+  align-items: center; }
+
+.amc--notification__text-left {
+  display: flex;
+  align-items: center; }
+
+.amc--notification__actions-right {
+  margin-left: auto; }

--- a/cms/static/sass/amc-specific.scss
+++ b/cms/static/sass/amc-specific.scss
@@ -2,6 +2,16 @@
   max-height: 48px;
 }
 
+body.view-settings {
+  .group-settings.basic {
+    // RED-348: Hide the "Invite your students" button from the Schedule & Details Page
+    //          This button is just a `mailto` link that we think it's better removed.
+    .list-actions {
+      display: none;
+    }
+  }
+}
+
 .a--howitworks-intro {
   padding: 12rem 0;
   background: linear-gradient(90deg,#154d64,#231f26);
@@ -91,8 +101,8 @@
   }
 
   &__text-left {
-    @include display(flex);
-    @include align-items(center);
+    display: flex;
+    align-items: center;
   }
 
   &__actions-right {


### PR DESCRIPTION
From @MHaton in [RED-348](https://appsembler.atlassian.net/browse/RED-348): 

> In Studio dwells a button under "Schedule and Details"
> It is bad.
> It's a mailto: link.
> It should really link to the courses's instructor dashboard enrollment tab, but instead it tries to get you to send an email.
> I hate it, and have hated it for years.



### Before and After

<kbd>![image](https://user-images.githubusercontent.com/645156/67091803-555cd580-f1b6-11e9-9126-49c8b4508245.png)</kbd>

### Not to Reviewers

The pull request contains a couple of CSS noise that should probably be ignored. I recommend focusing on the SCSS changes only.

The CSS noise happened because the CSS file is stale and hasn't been compiled for years. I'm not even sure if it's important at all. I did the compile anyway:

```
$ sassc --version
sassc 0.10.0
$ sassc cms/static/sass/amc-specific.scss cms/static/css/amc-specific.css
```