### PR TITLE
Amir/uw.hawthorn/hide completion mark

### DIFF
--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -78,3 +78,11 @@ body.view-instructor_statistics main {
     width: 1640px;
   }
 }
+
+.complete-checkmark {
+  display: none !important;
+}
+
+.check-circle {
+  display: none !important;
+}

--- a/lms/static/sass/_customer-specific.scss
+++ b/lms/static/sass/_customer-specific.scss
@@ -86,3 +86,7 @@ body.view-instructor_statistics main {
 .check-circle {
   display: none !important;
 }
+
+.search-results .search-results-item .result-type {
+  bottom: 10px;
+}

--- a/lms/templates/design-templates/header/_header-uw.html
+++ b/lms/templates/design-templates/header/_header-uw.html
@@ -187,4 +187,5 @@ from django.utils.translation import ugettext as _
     // remove trailing slash from jump to id
     $("a:contains('Course Team')").attr("href", $("a:contains('Course Team')").attr("href"));
   });
+
 </script>

--- a/lms/templates/design-templates/live-blocks/dashboard-course-listing/_dashboard-course-listing-01.html
+++ b/lms/templates/design-templates/live-blocks/dashboard-course-listing/_dashboard-course-listing-01.html
@@ -462,3 +462,11 @@ from student.helpers import (
 <%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">
     DateUtilFactory.transform(iterationKey=".localized-datetime");
 </%static:require_module_async>
+
+<script>
+  // hide course listing when user search something via dashboard search
+  $(".a--discovery-search-01__search-button").click(function(){
+    //if($(".search-count")[0]){$(".a--dashboard-course-listing-01").hide()};
+    $(".a--dashboard-course-listing-01").hide();
+  });
+</script>


### PR DESCRIPTION
- Hide completion tracking checkmark on outline and courseware: We need to turn on completion tracking to fix start/resume button but UW is not interested in to see the completion tracking icons in UI

- Hide course listing when the user search something via dashboard search