### PR TITLE
Stop search indexing certificates

### DIFF
--- a/lms/templates/certificates/accomplishment-base.html
+++ b/lms/templates/certificates/accomplishment-base.html
@@ -20,7 +20,7 @@ course_mode_class = course_mode if course_mode else ''
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="robots" content="noindex">
+    <meta name="robots" content="noindex,nofollow" />
 
     <title>${document_title}</title>
 

--- a/lms/templates/certificates/accomplishment-base.html
+++ b/lms/templates/certificates/accomplishment-base.html
@@ -20,6 +20,7 @@ course_mode_class = course_mode if course_mode else ''
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
 
     <title>${document_title}</title>
 


### PR DESCRIPTION
Matthew has reported the following: "Certificates are indexed by search engines (even when the site is not)".

This was a bug. Certificates are not using the same base template so they didn't have the "noindex" meta tag. Now I have added it to be there - regardless of the sites indexing settings. Realistically, it's logical not to have the certs indexed.