### PR TITLE
Feat: add accomplishment_date_title to cert_content so we can override via studio advance settings

### DIFF
--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -42,7 +42,7 @@ cert_content = get_certificate_content(course_id)
                     <div class="accomplishment-statement-detail">
 
                         <dl class="wrapper-accomplishment-metadata accomplishment-date">
-                            <dt class="label copy copy-meta">Date of Completion</dt>
+                            <dt class="label copy copy-meta">${cert_content['accomplishment_date_title']}</dt>
                             <dd class="value copy copy-meta" style="-webkit-margin-start:0; margin-left:0">${certificate_date_issued}</dd>
                         </dl>
                     </div>

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -81,7 +81,7 @@ cert_content = get_certificate_content(course_id)
             <div class="wrapper-metadata">
                
                 <dl class="metadata accomplishment-id" style="width: auto">
-                    <dt class="label copy copy-meta">Verify the authenticity of this certificate at</dt>
+                    <dt class="label copy copy-meta">${cert_content['accomplishment_id_title']}</dt>
                     <dd class="value copy copy-meta" style="white-space: nowrap"><a href="${url}/certificates/user/${accomplishment_user_id}/course/${course_id}">${url}/certificates/user/${accomplishment_user_id}/course/${course_id}</a></dd>
                 </dl>
 

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -617,6 +617,7 @@
       "accomplishment_copy_description_full": "has successfully completed",
       "accomplishment_copy_course_description": "a DHIS2 Academy online course offered by the University of Oslo",
       "accomplishment_date_title": "Date of Completion",
+      "accomplishment_id_title": "Verify the authenticity of this certificate at",
     }
 
     config = CertificateHtmlViewConfiguration.get_config()

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -616,6 +616,7 @@
       "certificate_subtitle": "This is to certify that",
       "accomplishment_copy_description_full": "has successfully completed",
       "accomplishment_copy_course_description": "a DHIS2 Academy online course offered by the University of Oslo",
+      "accomplishment_date_title": "Date of Completion",
     }
 
     config = CertificateHtmlViewConfiguration.get_config()


### PR DESCRIPTION
DHIS2 asked us to change the Cert lang to French. We can do it via Studio Advance settings but the accomplishment_date text and accomplishments title are not accessible from Studio. This PR makes the studio accomplishment_date title text and accomplishments text accessible for us to change it to desired lang customer asks us.