### PR TITLE
apply fixes to cert overrides

### DIFF
--- a/lms/templates/certificates/_accomplishment-header.html
+++ b/lms/templates/certificates/_accomplishment-header.html
@@ -7,9 +7,9 @@
     <header class="header-app" role="banner">
         <h1 class="header-app-title">
             <a class="logo" href="${request.site}" style="width: auto;">
-                <img class="a--accomplishment--header-logo" style="width: ${get_certificates_settings()['header_logo_width']}; height: auto;" src="${get_certificates_settings()['header_logo']}" alt="${get_certificates_settings()['platform_name']}" />
+                <img class="a--accomplishment--header-logo" style="width: ${get_certificates_settings()['header_logo_width']}; height: auto;" src="${get_certificates_settings()['header_logo']}" alt="${get_certificates_settings()['platform_name_amc']}" />
             </a>
-            <span class="sr-only">${get_certificates_settings()['platform_name']}</span>
+            <span class="sr-only">${get_certificates_settings()['platform_name_amc']}</span>
         </h1>
     </header>
 

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -6,7 +6,8 @@ course_mode_class = course_mode if course_mode else ''
 
 cert_settings = get_certificates_settings(context)
 
-cert_org_name = cert_settings.get('certificate_custom_org_name') if (cert_settings.get('certificate_custom_org_name') != "") else accomplishment_copy_course_org
+cert_org_name_base = cert_settings.get('certificate_custom_org_name') if (cert_settings.get('certificate_custom_org_name') != "") else accomplishment_copy_course_org
+cert_org_name = accomplishment_copy_course_org if (context.get('partner_short_name_overridden', False)) else cert_org_name_base
 %>
 
 <main class="a--accomplishment--wrapper a--accomplishment--main">
@@ -44,7 +45,7 @@ cert_org_name = cert_settings.get('certificate_custom_org_name') if (cert_settin
                 % endif
               </span>
               <h3 class="course-info">
-                ${cert_org_name} | ${course_number} ${_('Certificate')} | ${cert_settings['platform_name']}
+                ${cert_org_name} | ${course_number} ${_('Certificate')} | ${cert_settings['platform_name_amc']}
               </h3>
             </div>
             <span class="vertical-divider-bar"></span>

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -356,7 +356,7 @@
     'header_logo_width': get_value('certificates', {}).get('header_logo_width', '240px'),
     'cert_logo': get_value('certificates', {}).get('cert_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
     'logo_width': get_value('certificates', {}).get('cert_logo_width', '160px'),
-    'platform_name': translate(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', '')), default=_('Platform Name')),
+    'platform_name_amc': translate(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', '')), default=_('Platform Name')),
     'certificate_banner_text': translate(get_value('certificates', {}).get('certificate_banner_text', course_context.get('document_banner', ''))),
     'header_text': translate(get_value('certificates', {}).get('header_text', ''), default=_('Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
     'short_platform_description': translate(get_value('certificates', {}).get('short_platform_description', '')),


### PR DESCRIPTION
Bryan's work on allowing Studio to override certain strings in course cert display had issues. Example:
- course Org override hierarchy should be:  setting in Studio advanced settings --- (if not set) --> setting in AMC Cert settings --- (if not set) --> default Org name
- in oder to achieve this we need to make a check if the override in Studio has been made. [This PR](https://github.com/appsembler/edx-platform/pull/668) adds the flag into context.
- context was also overriding the Platform name (which is not to be overridden in Studio - no setting in Advanced Settings). I changed our variable name (`platform_name` -> `platform_name_amc`) and edited templates where it was called.