### PR TITLE
Fixed certificate course.display_organization override bug

### DIFF
--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -6,8 +6,16 @@ course_mode_class = course_mode if course_mode else ''
 
 cert_settings = get_certificates_settings(context)
 
-cert_org_name_base = cert_settings.get('certificate_custom_org_name') if (cert_settings.get('certificate_custom_org_name') != "") else accomplishment_copy_course_org
-cert_org_name = accomplishment_copy_course_org if (context.get('partner_short_name_overridden', False)) else cert_org_name_base
+if partner_short_name_overridden:
+  # Use the course.display_organization if overridden
+  cert_org_name = course_partner_short_name
+else:
+  if cert_settings.get('certificate_custom_org_name'):
+    # Use the SiteConfiguration certificate.certificate_custom_org_name` if configured
+    cert_org_name = cert_settings.get('certificate_custom_org_name')
+  else:
+    # Use the course.org if none is available
+    cert_org_name = accomplishment_copy_course_org
 %>
 
 <main class="a--accomplishment--wrapper a--accomplishment--main">


### PR DESCRIPTION
Fixes RED-1329

Test in conjunction with https://github.com/appsembler/edx-platform/pull/676

### Bug Description

In addition to what's described in RED-1329. I've found that setting `course.display_organization` makes `organization.short_name` appears instead. Which is not what we want at all.


### Solution
Used the new `partner_short_name_overridden` to avoid falling back to `org.short_name`.

I've refactored the code into nested `if` statements so it's much easier to reason about.

I wish we can add tests to our theme because it has sooo much logic!