### PR TITLE
Fix missing spaces in trial message

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -96,7 +96,7 @@ from openedx.core.release import RELEASE_LINE
           <section class="amc--notification__area" style="background-color: #fff; padding: 1px 0;">
             <div class="amc--notification__content amc--notification--tier-expiration" style="width: 100%; max-width: 1280px; min-width: 900px; margin: 15px auto; background-color: #E4572E; box-shadow: 0 3px 8px 0 rgba(0,0,0,0.2); color: #fff; font-size: 14px; display: -ms-flexbox; display: flex; -ms-flex-align: center; align-items: center; padding: 20px 30px; border-radius: 30px;">
               <div class="amc--notification__text-left">
-                Your Tahoe Trial <strong>has expired</strong>!
+                <span>Your Tahoe Trial <strong>has expired</strong>!</span>
               </div>
               <div class="amc--notification__actions-right" style="margin-left: auto;">
                 <a class="amc--notification--button secondary-action" href="https://www.appsembler.com/about/contact-us" target="_blank" style="padding: 7px 20px; margin: 5px; border-radius: 30px; text-decoration: none; background: none; border: 2px solid #fff; color: #fff; font-weight: bolder;">Contact us</a>
@@ -108,7 +108,7 @@ from openedx.core.release import RELEASE_LINE
           <section class="amc--notification__area" style="background-color: #fff; padding: 1px 0;">
             <div class="amc--notification__content amc--notification--tier-expiration" style="width: 100%; max-width: 1280px; min-width: 900px; margin: 15px auto; background-color: #fff; box-shadow: 0 3px 8px 0 rgba(0,0,0,0.2); color: #1a1a1a; font-size: 14px; display: -ms-flexbox; display: flex; -ms-flex-align: center; align-items: center; padding: 20px 30px; border-radius: 30px;">
               <div class="amc--notification__text-left">
-                Your Tahoe Trial <strong>expires</strong> in: <span class="expiration-info" style="font-size: 16px; font-weight: bolder;">${tier_expires_in}</span>
+                <span>Your Tahoe Trial <strong>expires</strong> in: <span class="expiration-info" style="font-size: 16px; font-weight: bolder;">${tier_expires_in}</span></span>
               </div>
               <div class="amc--notification__actions-right" style="margin-left: auto;">
                 <a class="amc--notification--button secondary-action" href="https://www.appsembler.com/about/contact-us" target="_blank" style="padding: 7px 20px; margin: 5px; border-radius: 30px; text-decoration: none; background: none; border: 2px solid #0090c1; color: #0090c1; font-weight: bolder;">Contact us</a>


### PR DESCRIPTION
It's very annoying issue. I've found a quick fix.

It could be fixed in CSS but I just chose not to.

### Before
<kbd>![image](https://user-images.githubusercontent.com/645156/93453129-f3cf4a80-f8e1-11ea-8f53-a24f3ea9c339.png)</kbd>

### After
I tried it in browser console because to avoid a long test cycle.

<kbd>![image](https://user-images.githubusercontent.com/645156/93453188-08134780-f8e2-11ea-814f-64a61d6f73a3.png)</kbd>
