### PR TITLE
Trial expiration page: cleanup, fix mako template

### DIFF
--- a/lms/templates/design-templates/pages/messages/site-expired.html
+++ b/lms/templates/design-templates/pages/messages/site-expired.html
@@ -1,1 +1,0 @@
-Your trial has expired!

--- a/lms/templates/static_templates/site-unavailable.html
+++ b/lms/templates/static_templates/site-unavailable.html
@@ -1,3 +1,4 @@
+## mako
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="/main-nohead-nofoot.html" />
 <%namespace name='static' file='/static_content.html'/>
@@ -11,7 +12,7 @@
 <div class="a--site-message">
 
   <section class="a--site-message__header a--container bs-container">
-    <img class="header-logo" src="${get_brand_logos()['logo_positive']}" alt="${_("{platform_name} Page Unavailable").format(platform_name=static.get_platform_name())}">
+    <img class="header-logo" src="${get_brand_logos()['logo_positive']}" alt="${_('{platform_name} Page Unavailable').format(platform_name=static.get_platform_name())}">
   </section>
 
   <section class="a--container bs-container a--site-message__content">


### PR DESCRIPTION
 - Fix an error with the Django class based views: `## mako` is needed, otherwise a broken page will show up.
 - Remove old template.

<kbd>![image](https://user-images.githubusercontent.com/645156/94030729-d2c99680-fdc6-11ea-80f0-a7a41a02ed86.png)</kbd>