### PR TITLE
Improve font sizes on cert print to prevent overflow

### DIFF
--- a/lms/static/sass/certificates/_certificate-template-01.scss
+++ b/lms/static/sass/certificates/_certificate-template-01.scss
@@ -337,11 +337,11 @@
         }
 
         .student-name {
-          font-size: 42pt;
+          font-size: 36pt;
         }
 
         .course-name-main {
-          font-size: 18pt;
+          font-size: 16pt;
         }
       }
     }


### PR DESCRIPTION
It was reported to us that longer course names push the cert to be printed on more than one page. Which is not nice. So I made adjustments to print font sizes of course name and person receiving the certificate. So now it will be nice again.