### PR TITLE
(Urgent) Workaround not found gettext files in Japanese

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -61,6 +61,7 @@ from openedx.core.release import RELEASE_LINE
     % endif
 
     <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+    <%include file="gettext_staticfiles_fixes/patch_missing_gettext_hack.html" />
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="path_prefix" content="${EDX_ROOT_URL}">
 

--- a/cms/templates/gettext_staticfiles_fixes
+++ b/cms/templates/gettext_staticfiles_fixes
@@ -1,0 +1,1 @@
+../../gettext_staticfiles_fixes

--- a/gettext_staticfiles_fixes/README.md
+++ b/gettext_staticfiles_fixes/README.md
@@ -1,0 +1,5 @@
+### Fixing the missing strings because of staticfiles issues
+
+This directory exists as a stopgap solution for the issue in `gettext` for international learners: https://appsembler.atlassian.net/browse/RED-1698 .
+
+This directory includes a file which is included both in LMS and Studio.

--- a/gettext_staticfiles_fixes/patch_missing_gettext_hack.html
+++ b/gettext_staticfiles_fixes/patch_missing_gettext_hack.html
@@ -1,0 +1,145 @@
+<script type="text/javascript">
+    (function (globals) {
+        if (globals.gettext) {
+            // gettext() function is sometimes not loaded reasons speculated
+            // about in RED-1698. In such case we patch it.
+            return;
+        }
+
+        /**
+         * From this line and below it's copied from:
+         *    `lms/static/js/i18n/en/djangojs.js`
+         */
+        var django = globals.django || (globals.django = {});
+
+        django.pluralidx = function (n) {
+            var v = (n != 1);
+            if (typeof (v) == 'boolean') {
+                return v ? 1 : 0;
+            } else {
+                return v;
+            }
+        };
+
+
+        /* gettext library */
+
+        django.catalog = django.catalog || {};
+
+
+        if (!django.jsi18n_initialized) {
+            django.gettext = function (msgid) {
+                var value = django.catalog[msgid];
+                if (typeof (value) == 'undefined') {
+                    return msgid;
+                } else {
+                    return (typeof (value) == 'string') ? value : value[0];
+                }
+            };
+
+            django.ngettext = function (singular, plural, count) {
+                var value = django.catalog[singular];
+                if (typeof (value) == 'undefined') {
+                    return (count == 1) ? singular : plural;
+                } else {
+                    return value[django.pluralidx(count)];
+                }
+            };
+
+            django.gettext_noop = function (msgid) {
+                return msgid;
+            };
+
+            django.pgettext = function (context, msgid) {
+                var value = django.gettext(context + '\x04' + msgid);
+                if (value.indexOf('\x04') != -1) {
+                    value = msgid;
+                }
+                return value;
+            };
+
+            django.npgettext = function (context, singular, plural, count) {
+                var value = django.ngettext(context + '\x04' + singular, context + '\x04' + plural, count);
+                if (value.indexOf('\x04') != -1) {
+                    value = django.ngettext(singular, plural, count);
+                }
+                return value;
+            };
+
+            django.interpolate = function (fmt, obj, named) {
+                if (named) {
+                    return fmt.replace(/%\(\w+\)s/g, function (match) {
+                        return String(obj[match.slice(2, -2)])
+                    });
+                } else {
+                    return fmt.replace(/%s/g, function (match) {
+                        return String(obj.shift())
+                    });
+                }
+            };
+
+
+            /* formatting library */
+
+            django.formats = {
+                "DATETIME_FORMAT": "N j, Y, P",
+                "DATETIME_INPUT_FORMATS": [
+                    "%Y-%m-%d %H:%M:%S",
+                    "%Y-%m-%d %H:%M:%S.%f",
+                    "%Y-%m-%d %H:%M",
+                    "%Y-%m-%d",
+                    "%m/%d/%Y %H:%M:%S",
+                    "%m/%d/%Y %H:%M:%S.%f",
+                    "%m/%d/%Y %H:%M",
+                    "%m/%d/%Y",
+                    "%m/%d/%y %H:%M:%S",
+                    "%m/%d/%y %H:%M:%S.%f",
+                    "%m/%d/%y %H:%M",
+                    "%m/%d/%y"
+                ],
+                "DATE_FORMAT": "N j, Y",
+                "DATE_INPUT_FORMATS": [
+                    "%Y-%m-%d",
+                    "%m/%d/%Y",
+                    "%m/%d/%y"
+                ],
+                "DECIMAL_SEPARATOR": ".",
+                "FIRST_DAY_OF_WEEK": "0",
+                "MONTH_DAY_FORMAT": "F j",
+                "NUMBER_GROUPING": "3",
+                "SHORT_DATETIME_FORMAT": "m/d/Y P",
+                "SHORT_DATE_FORMAT": "m/d/Y",
+                "THOUSAND_SEPARATOR": ",",
+                "TIME_FORMAT": "P",
+                "TIME_INPUT_FORMATS": [
+                    "%H:%M:%S",
+                    "%H:%M:%S.%f",
+                    "%H:%M"
+                ],
+                "YEAR_MONTH_FORMAT": "F Y"
+            };
+
+            django.get_format = function (format_type) {
+                var value = django.formats[format_type];
+                if (typeof (value) == 'undefined') {
+                    return format_type;
+                } else {
+                    return value;
+                }
+            };
+
+            /* add to global namespace */
+            globals.pluralidx = django.pluralidx;
+            globals.gettext = django.gettext;
+            globals.ngettext = django.ngettext;
+            globals.gettext_noop = django.gettext_noop;
+            globals.pgettext = django.pgettext;
+            globals.npgettext = django.npgettext;
+            globals.interpolate = django.interpolate;
+            globals.get_format = django.get_format;
+
+            django.jsi18n_initialized = true;
+        }
+
+    }(this));
+</script>

--- a/lms/templates/gettext_staticfiles_fixes
+++ b/lms/templates/gettext_staticfiles_fixes
@@ -1,0 +1,1 @@
+../../gettext_staticfiles_fixes


### PR DESCRIPTION
Stopgap for RED-1698 staticfiles issue which affects up to 33% of our international customers.

This is a stopgap solution for the issue in `gettext` for international learners: https://appsembler.atlassian.net/browse/RED-1698

This does _not_ resolve the issue, but makes LMS and Studio _not_ break.

### Please prioritize quickly but review carefully

A customer is launching their site on Monday February 15th, 2021 and there's a bug that's blocking them. We cannot let this wait too much and ideally deploy on Monday. However, I don't want to skip proper review and make a bigger problem.

### This is a stopgap, where's the full fix?

The root cause fix should be in https://github.com/appsembler/configuration/pull/348 but I don't want to wait for another round (usually 1-2 weeks) of customer testing and debugging so I'm fixing it twice