### PR TITLE
Support TAHOE_STUDIO_LOCAL_LOGIN urls

### DIFF
--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -4,6 +4,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%!
   from django.urls import reverse
+  from django.conf import settings
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
 %>
@@ -17,7 +18,7 @@
   <div class="a--howitworks-intro__container">
     <h1>Welcome to Open edX Studio!</h1>
     <h4>Sign in to start authoring your courses.</h4>
-    <a href="${reverse('login_redirect_to_lms')}" class="a--howitworks-intro__login-cta">Sign in</a>
+    <a href="${settings.FRONTEND_LOGIN_URL}" class="a--howitworks-intro__login-cta">Sign in</a>
   </div>
 </div>
 

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -258,7 +258,7 @@
               </li>
           % endif
           <li class="nav-item nav-not-signedin-signin">
-            <a class="action action-signin" href="${reverse('login_redirect_to_lms')}">${_("Sign In")}</a>
+            <a class="action action-signin" href="${settings.FRONTEND_LOGIN_URL}">${_("Sign In")}</a>
           </li>
         </ol>
       </nav>


### PR DESCRIPTION
Using the `FRONTEND_LOGIN_URL` to make the `TAHOE_STUDIO_LOCAL_LOGIN` work transparently.