### PR TITLE
Fix 500 error in Studio

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -157,7 +157,7 @@ from openedx.core.release import RELEASE_LINE
       % endif
 
       <div id="page-alert">
-      <%include file="widgets/deprecated-course-key-warning.html" args="course=context_course" />
+      <%include file="/widgets/deprecated-course-key-warning.html" args="course=context_course" />
       <%block name="page_alert"></%block>
       </div>
 


### PR DESCRIPTION
RED-1930. The error was introduced by https://github.com/appsembler/edx-theme-customers/pull/148. This PR fixes the relative path in `customer_specific` otherwise a [500 error would happen](https://appsembler.slack.com/archives/C01JJ0L9QV7/p1617717190004100).