### PR TITLE
Initial tox and gitbub actions: avoid getting stale css

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: customer themes
+
+on:
+  push:
+    branches: ['juniper/tahoe']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.8]
+        tox-env:
+          - verify
+    steps:
+     - uses: actions/checkout@v2
+     - name: Set up Python ${{ matrix.python-version }}
+       uses: actions/setup-python@v2
+       with:
+         python-version: ${{ matrix.python-version }}
+     - name: Install dependencies
+       run: |
+         pip install tox
+     - name: Test with tox
+       run: tox -e ${{ matrix.tox-env }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.tox

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Customer-specific theme
+This repo has the customer themes.
+
+## How to: Compile the `amc-specific.scss` file
+
+On your devstack run:
+
+```
+$ tox -e compile
+```
+
+Commit the changes and make a pull request.

--- a/cms/static/css/amc-specific.css
+++ b/cms/static/css/amc-specific.css
@@ -99,3 +99,6 @@ body.view-settings .group-settings.basic .list-actions {
     max-width: 48rem;
     width: 80%;
     margin-bottom: 5rem; }
+
+.xblock .mentoring .copyright {
+  display: none; }

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -ex
+
+# Run via `tox -e compile`
+pysassc cms/static/sass/amc-specific.scss cms/static/css/amc-specific.css

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# Run this script via `$ tox -e verify`
+if git diff --no-ext-diff --quiet --exit-code; then
+  echo "Success: The CSS file is in sync with the SCSS file."
+else
+  echo "Error: CSS is out of sync"
+  echo "=== Start: Git diff ==="
+  git --no-pager diff
+  echo "=== End: Git diff ==="
+  echo 'Error: The CSS file is out of sync with the SCSS file.'
+  echo 'The git diff above shows the difference.'
+  echo 'Please use "$ tox -e compile" locally to compile the SCSS file.'
+  exit 1
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = compile,verify
+skipsdist = True
+
+[testenv]
+basepython=python3
+deps = libsass==0.20.1
+allowlist_externals =
+    bash
+
+[testenv:compile]
+commands =
+    bash {toxinidir}/scripts/compile.sh
+
+[testenv:verify]
+commands =
+    bash {toxinidir}/scripts/compile.sh
+    bash {toxinidir}/scripts/verify.sh
+


### PR DESCRIPTION
### Changes
 - Add `tox` to compile SCSS files easily via `tox -e compile`
 - Add GitHub actions to block pull requests from unless the CSS file is compiled

Partially fixes https://github.com/appsembler/edx-theme-customers/issues/91 

### What does the error look like?

<kbd>![image](https://user-images.githubusercontent.com/645156/113992473-2f206f00-985c-11eb-8715-b3ed0b00ed17.png)</kbd>


### More details?
This what the GitHub actions shows when it fails:

```
Error: CSS is out of sync
=== Start: Git diff ===
diff --git a/cms/static/css/amc-specific.css b/cms/static/css/amc-specific.css
index 61c5a1e..2d4bb1d 100644
--- a/cms/static/css/amc-specific.css
+++ b/cms/static/css/amc-specific.css
@@ -99,3 +99,6 @@ body.view-settings .group-settings.basic .list-actions {
     max-width: 48rem;
     width: 80%;
     margin-bottom: 5rem; }
+
+.xblock .mentoring .copyright {
+  display: none; }
=== End: Git diff ===
Error: The CSS file is out of sync with the SCSS file.
The git diff above shows the difference.
Please use "$ tox -e compile" locally to compile the SCSS file.
ERROR: InvocationError for command /bin/bash scripts/verify.sh (exited with code 1)
____________ summary ____________
ERROR:   verify: commands failed
```

