### PR TITLE
skip google tag manager if not ID is set

### DIFF
--- a/lms/templates/body-initial.html
+++ b/lms/templates/body-initial.html
@@ -5,12 +5,13 @@
 %>
 ${_render_hijack_notification((request))}
 
-% if (get_global_settings().get('customer_gtm_id') != ""):
-  <%
-    customerGtmId = get_global_settings().get('customer_gtm_id')
-  %>
+<%
+customer_gtm_id = get_global_settings().get('customer_gtm_id')
+%>
+
+% if customer_gtm_id:
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${customerGtmId | n, js_escaped_string}"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${customer_gtm_id | n, js_escaped_string}"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
 % endif

--- a/lms/templates/partials/analytics.html
+++ b/lms/templates/partials/analytics.html
@@ -20,10 +20,11 @@
   endif
 %>
 
-% if (get_global_settings().get('customer_gtm_id') != ""):
-  <%
-    customerGtmId = get_global_settings().get('customer_gtm_id')
-  %>
+<%
+  customer_gtm_id = get_global_settings().get('customer_gtm_id')
+%>
+
+% if customer_gtm_id:
   <script>
     dataLayer = [{
       'visitorType': '${userType | n, js_escaped_string}',
@@ -35,7 +36,7 @@
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','${customerGtmId | n, js_escaped_string}');</script>
+  })(window,document,'script','dataLayer','${customer_gtm_id | n, js_escaped_string}');</script>
   <!-- End Google Tag Manager -->
 % endif
 


### PR DESCRIPTION
The previous check was incorrect, because it doesn't filter `None`.
Python thinks that `None` and `""` are different.

However, both are falsy values!

```
$ python
>>> "" == None
False
>>> not ""
True
>>> not False
True
>>> not None
True
```

That's why we should use `if something:` instead of `if something == False:` in most cases.

### Customer complaint:

Customers are complaining about this issue and thinking it's an error: https://secure.helpscout.net/conversation/1626057730/7790#thread-4745087504