### PR TITLE
Add option for PII->GTM to Site Settings

### DIFF
--- a/lms/templates/partials/analytics.html
+++ b/lms/templates/partials/analytics.html
@@ -22,15 +22,36 @@
 
 <%
   customer_gtm_id = get_global_settings().get('customer_gtm_id')
+  customer_gtm_enable_pii = get_global_settings().get('customer_gtm_enable_pii', False)
 %>
 
 % if customer_gtm_id:
-  <script>
-    dataLayer = [{
-      'visitorType': '${userType | n, js_escaped_string}',
-      'courseName': '${courseName | n, js_escaped_string}'
-    }];
-  </script>
+  % if customer_gtm_enable_pii:
+    <%
+      if user.is_authenticated:
+        userEmail = user.email
+        userID = user.id
+      else:
+        userEmail = 'Not authenticated'
+        userID = 'Not authenticated'
+      endif
+    %>
+    <script>
+      dataLayer = [{
+        'visitorType': '${userType | n, js_escaped_string}',
+        'courseName': '${courseName | n, js_escaped_string}',
+        'userEmail': '${userEmail | n, js_escaped_string}',
+        'userID': '${userID | n, js_escaped_string}',
+      }];
+    </script>
+  % else:
+    <script>
+      dataLayer = [{
+        'visitorType': '${userType | n, js_escaped_string}',
+        'courseName': '${courseName | n, js_escaped_string}'
+      }];
+    </script>
+  % endif
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -69,6 +69,7 @@
     'enable_legacy_courseware_nav': get_value('enable_legacy_courseware_nav', True),
     'customer_gtm_enabled': get_value('customer_gtm_enabled', False),
     'customer_gtm_id': get_value('customer_gtm_id', ""),
+    'customer_gtm_enable_pii': get_value('customer_gtm_enable_pii', False),
     'default_og_image': get_value('default_og_image', ''),
     'og_image_use_course_images': get_value('og_image_use_course_images', ''),
     'header_logo_target': get_value('header_logo_target', '/'),


### PR DESCRIPTION
## Change description

When installing Intercom, there's no identifiable information that Google Tag Manager has to pass to Intercom in order to identify the person that is messaging support. This epic an option to extend the data sent to DataLayer with the userID and userEmail.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#2577](https://appsembler.atlassian.net/browse/RED-2577?focusedCommentId=39872&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-39872) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
