### PR TITLE
customer-branded singup template for auth0

### DIFF
--- a/lms/templates/tahoe_auth0/register.html
+++ b/lms/templates/tahoe_auth0/register.html
@@ -1,0 +1,266 @@
+## mako
+<%!
+    from django.urls import reverse
+    from django.utils.translation import ugettext as _
+    from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<%namespace name='static' file='/static_content.html'/>
+<%namespace file='/theme-variables.html' import="get_global_settings" />
+<%namespace file='/main.html' import="add_login_query"/>
+
+<%inherit file="/main.html" />
+
+<%block name="pagetitle">${_("Sign Up to {name}").format(name=organization_name)}</%block>
+
+<%block name="js_extra">
+
+<script>
+  jQuery(function ($) {
+    var form = $('.register-form');
+    var auth0LoginLink = $('.auth0-login-link');
+    var submitButton = $('.js-register');
+
+    form.submit(function (e) {
+      e.preventDefault();
+      var csrftoken = $('[name=csrfmiddlewaretoken]').val();
+      var formActionUrl = form.data('action');
+      submitButton.prop('disabled', true);
+
+      fetch(formActionUrl, {
+        method: 'POST',
+        headers: {
+          'X-CSRFToken': csrftoken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: $('#register-name').val(),
+          username: $('#register-username').val(),
+          email: $('#register-email').val(),
+          password: $('#register-password').val(),
+          // TODO: Add support for custom fields
+          metadata: {
+              extra_arg: "some value",
+              another_arg: "another value",
+          }
+        })
+      }).then((resp) => {
+        if (resp.ok){
+          alert('Congrats! you have created your account. You will be redirected to the login page.')
+          window.location.href = auth0LoginLink.attr('href');
+        } else {
+          // TODO: Add error handling when needed
+          submitButton.prop('disabled', false);
+          console.error('Error: ' + resp.text);
+          alert(resp.text);
+        }
+      }).catch((error) => {
+        console.error(error);
+      });
+    });
+  });
+</script>
+</%block>
+
+
+<div class="section-bkg-wrapper">
+  <div
+    id="login-and-registration-container"
+    class="login-register bs-container"
+  >
+    <section id="login-anchor" class="form-type">
+      <div id="login-form" class="form-wrapper hidden"></div>
+    </section>
+    <section id="register-anchor" class="form-type">
+      <div id="register-form" class="form-wrapper">
+        <div class="js-form-feedback" aria-live="assertive" tabindex="-1"></div>
+        <div class="toggle-form">
+          <span class="text">${_("Already have an {platform_name} account?").format(platform_name=organization_name)}</span>
+          <a href="${add_login_query(get_global_settings()['login_url'], '/dashboard')}" class="auth0-login-link form-toggle" data-type="login">${_("Sign in.")}</a>
+        </div>
+        <form
+          id="register"
+          class="register-form"
+          autocomplete="off"
+          tabindex="-1"
+          method="POST"
+          data-action="${reverse('tahoe_auth0:register_api')}"
+        >
+          <h2>${_("Create an Account")}</h2>
+          <div class="required-fields">
+            <div class="form-field text-name">
+              <label for="register-name" class="focus-out">
+                <span class="label-text">${_('Full Name')}</span>
+                <span
+                  id="register-name-required-label"
+                  class="label-required hidden"
+                >
+                </span>
+                <span
+                  class="icon fa"
+                  id="register-name-validation-icon"
+                  aria-hidden="true"
+                >
+                </span>
+              </label>
+              <input
+                id="register-name"
+                type="text"
+                name="name"
+                class="input-block"
+                aria-describedby="register-name-desc register-name-validation-error"
+                maxlength="255"
+                required=""
+                value=""
+              />
+              <span
+                id="register-name-validation-error"
+                class="tip error hidden"
+                aria-live="assertive"
+              >
+                <span class="sr-only"> </span>
+                <span id="register-name-validation-error-msg"> </span>
+              </span>
+              <span class="tip tip-input hidden" id="register-name-desc"
+                >${_("This name will be used on any certificates that you earn.")}
+              </span>
+            </div>
+            <div class="form-field text-username">
+              <label for="register-username" class="focus-out">
+                <span class="label-text">${_("Public Username")} </span>
+                <span
+                  id="register-username-required-label"
+                  class="label-required hidden"
+                >
+                </span>
+                <span
+                  class="icon fa"
+                  id="register-username-validation-icon"
+                  aria-hidden="true"
+                >
+                </span>
+              </label>
+              <input
+                id="register-username"
+                type="text"
+                name="username"
+                class="input-block"
+                aria-describedby="register-username-desc register-username-validation-error"
+                minlength="2"
+                maxlength="30"
+                required=""
+                value=""
+              />
+              <span
+                id="register-username-validation-error"
+                class="tip error hidden"
+                aria-live="assertive"
+              >
+                <span class="sr-only"> </span>
+                <span id="register-username-validation-error-msg"> </span>
+              </span>
+              <span class="tip tip-input hidden" id="register-username-desc"
+                >${_("The name that will identify you in your courses. It cannot be changed later.")}
+              </span>
+            </div>
+            <div class="form-field email-email">
+              <label for="register-email" class="focus-out">
+                <span class="label-text">${_('Email address')}</span>
+                <span
+                  id="register-email-required-label"
+                  class="label-required hidden"
+                >
+                </span>
+                <span
+                  class="icon fa"
+                  id="register-email-validation-icon"
+                  aria-hidden="true"
+                >
+                </span>
+              </label>
+              <input
+                id="register-email"
+                type="email"
+                name="email"
+                class="input-block"
+                aria-describedby="register-email-desc register-email-validation-error"
+                minlength="3"
+                maxlength="254"
+                required=""
+                value=""
+              />
+              <span
+                id="register-email-validation-error"
+                class="tip error hidden"
+                aria-live="assertive"
+              >
+                <span class="sr-only"> </span>
+                <span id="register-email-validation-error-msg"> </span>
+              </span>
+              <span class="tip tip-input hidden" id="register-email-desc"
+                >${_("This is what you will use to login.")}
+              </span>
+            </div>
+            <div class="form-field password-password">
+              <label for="register-password" class="focus-out">
+                <span class="label-text">${_('Password')}</span>
+                <span
+                  id="register-password-required-label"
+                  class="label-required hidden"
+                >
+                </span>
+                <span
+                  class="icon fa"
+                  id="register-password-validation-icon"
+                  aria-hidden="true"
+                >
+                </span>
+              </label>
+              <input
+                id="register-password"
+                type="password"
+                name="password"
+                class="input-block"
+                aria-describedby="register-password-desc register-password-validation-error"
+                minlength="2"
+                maxlength="75"
+                required=""
+                value=""
+              />
+              <span
+                id="register-password-validation-error"
+                class="tip error hidden"
+                aria-live="assertive"
+              >
+                <span class="sr-only"> </span>
+                <span id="register-password-validation-error-msg"> </span>
+              </span>
+              <span class="tip tip-input hidden" id="register-password-desc">
+                  ${_("Your password must contain at least 2 characters.")}
+              </span>
+            </div>
+            <div class="form-field plaintext-honor_code">
+              <span class="plaintext-field"
+                >${Text(_('By creating an account you are agreeing to the {site_name} {terms_link}.')).format(
+                      site_name=Text(organization_name),
+                      terms_link=HTML('<a href="/tos" rel="noopener" target="_blank">{terms_text}</a>').format(
+                        terms_text=_('Terms of Service and Privacy Policy'),
+                      ),
+                  )}</span>
+            </div>
+          </div>
+          <button
+            type="submit"
+            class="
+              action action-primary action-update
+              js-register
+              register-button
+            "
+          >
+            ${_("Create Account")}
+          </button>
+        </form>
+      </div>
+    </section>
+  </div>
+</div>


### PR DESCRIPTION
RED-2794. ~This is a terrible-looking template but it works okay. Apparently, I've lost my drawing skills over the years.~

I've stolen from both `login_and_register.html` and `register.underscore` and now it looks okay'ish.

### TODO
 - [x] Copy html from the edX registration form

### Screenshot of Auth0 form
![image](https://user-images.githubusercontent.com/645156/152359926-9e26937f-212e-4726-b171-eb052abfe49d.png)
