### PR TITLE
fix auth0 alert: display response body on error

### DIFF
--- a/lms/templates/tahoe_auth0/register.html
+++ b/lms/templates/tahoe_auth0/register.html
@@ -51,8 +51,10 @@
         } else {
           // TODO: Add error handling when needed
           submitButton.prop('disabled', false);
-          console.error('Error: ' + resp.text);
-          alert(resp.text);
+          resp.text().then(function (text) {
+            console.error('Error: ' + text);
+            alert(text);
+          });
         }
       }).catch((error) => {
         console.error(error);


### PR DESCRIPTION
Without this fix, it'll show `alert()` but with useless message. 

This is all temporary and proper error messages should be used.

I'm relying on Matej to fix/beautify this form one day.