### PR TITLE
Theme version initial

### DIFF
--- a/lms/static/sass/base/_site-config-variables-adapter.scss
+++ b/lms/static/sass/base/_site-config-variables-adapter.scss
@@ -1,0 +1,175 @@
+$brand-primary-color: $primary_brand_color;
+$brand-accent-color: $primary_brand_color;
+$navbar-style: "white";  // brand or white
+$base-text-color: $text_color;
+
+$primary-font-name: $selected_font;
+$primary-font-weight-light: 300;
+$primary-font-weight-regular: 400;
+$primary-font-weight-bold: 700;
+$primary-font-weight-black: 800;
+$accent-font-name: $selected_font;
+
+$font-size-base-body: calcRem(16);
+$line-height-base-body: 170%;
+$font-size-h1: calcRem(42);
+$line-height-h1: 130%;
+$font-size-h2: calcRem(30);
+$line-height-h2: 130%;
+$font-size-h3: calcRem(26);
+$line-height-h3: 130%;
+$font-size-h4: calcRem(22);
+$line-height-h4: 130%;
+
+$global-font-h1: "primary-font-bold";
+$global-font-h2: "primary-font-bold";
+$global-font-h3: "primary-font-bold";
+$global-font-h4: "primary-font-bold";
+$global-font-base-body: "primary-font-regular";
+$global-font-header-links: "primary-font-regular";
+$global-font-cta-buttons: "primary-font-regular";
+
+$cta-button-bg: $buttons_accents_color;
+$cta-button-text-color: $buttons_text_color;
+$cta-button-border: 2px solid $buttons_accents_color;
+$buttons-border-radius: calcRem(50);
+
+$header-bg-color: $header_background_color;
+$header-logo-height: calcRem($header_logo_height);
+$header-padding-top: calcRem(15);
+$header-padding-bottom: $header-padding-top;
+$header-padding-sm-top: calcRem(15);
+$header-padding-sm-bottom: calcRem(15);
+$header-group-separation: calcRem(40);
+$header-font-size: calcRem($header_font_size);
+$header-text-color: $header_text_color;
+$navbar-button-border: 2px solid $header_buttons_color;
+$navbar-button-bg: $header_buttons_color;
+$navbar-button-text-color: $header_buttons_text_color;
+$navbar-anchor-underline-color: $buttons_accents_color;
+$navbar-link-hover: "expanding-underline";  // can be "hover-pop", "expanding-underline", "brand-color" or "opacity"
+
+$display-navbar-logo-positive: calcDisplayLogoPositive($navbar-style);
+$display-navbar-logo-negative: calcDisplayLogoNegative($navbar-style);
+
+$nav-toggle-bar-width: calcRem(36);
+$nav-toggle-bar-height: calcRem(4);
+$nav-toggle-bar-radius: calcRem(4);
+$nav-toggle-bar-margin: calcRem(20);
+$nav-toggle-bar-color: $header-text-color;
+$nav-toggle-bar-separation: calcRem(10);
+$nav-toggle-bar-pulsar-color: $brand-primary-color;
+$nav-toggle-bar-pulsar-visible: false;
+
+$slideout-menu-text-color: #fff;
+$slideout-menu-background-color: $brand-primary-color;
+$slideout-menu-text-size: calcRem(16);
+$slideout-menu-item-padding: calcRem(14);
+
+$base-letter-spacing: 0;
+
+
+$footer-padding-top: calcRem(40);
+$footer-font-size: calcRem($footer_font_size);
+$footer-padding-bottom: 1.5*$footer-padding-top;
+$footer-bg-color: $footer_background_color;
+$footer-top-border: none;
+$footer-text-color: $footer_text_color;
+$footer-link-color: $footer_links_color;
+$footer-link-hover-color: lighten($footer_links_color, 15%);
+$footer-link-breathe-space: calcRem(15);
+$footer-logo-breathe-space: calcRem(30);
+$footer-logo-padding-vertical: calcRem(10);
+$footer-logo-width: calcRem($footer_logo_height);
+$footer-logo-opacity: 1;
+$footer-copyright-text-size: calcRem(12);
+$footer-copyright-text-color: $footer_copyright_text_color;
+$footer-copyright-breathe-space: calcRem(10);
+
+
+// search elements settings
+$search-bar-vertical-margin: calcRem(30);
+$search-bar-wrapper-padding: 0 calcRem(20);
+$search-bar-bottom-border: 1px solid rgba($base-text-color, 0.25);
+$search-bar-inner-container-padding: calcRem(30) 0;
+$search-bar-big-message-text-size: calcRem(24);
+$search-bar-big-message-text-color: rgba($base-text-color, 0.7);
+$search-bar-icon-button-color: rgba($base-text-color, 0.7);
+$search-bar-icon-button-color-lighter: rgba($base-text-color, 0.3);
+$search-bar-icon-button-font-size: calcRem(20);
+$search-filter-padding: calcRem(10) calcRem(15);
+$search-filter-margin: calcRem(7.5);
+$search-filter-bg-color: rgba($base-text-color, 0.4);
+$search-filter-text-color: rgba($base-text-color, 0.8);
+$facets-big-heading-font-size: calcRem(20);
+$facets-big-heading-margin: 0 0 calcRem(20);
+$facets-big-heading-padding: $facets-big-heading-margin;
+$facets-group-title-font-size: calcRem(16);
+$facets-group-title-margin: calcRem(15) 0 calcRem(15);
+$facets-group-title-color: $brand-primary-color;
+$facets-group-list-padding: 0 0 calcRem(15);
+$single-facet-bottom-border: 1px solid rgba($base-text-color, 0.2);
+$single-facet-padding: calcRem(7.5) 0;
+$single-facet-selected-opacity: 0.6;
+$facet-font-size: calcRem(16);
+$facet-results-count-font-size: calcRem(12);
+$facet-results-count-bg-color: $brand-accent-color;
+$facet-results-count-text-color: #fff;
+$facet-results-count-padding: calcRem(3) calcRem(8);
+$facet-results-count-border-radius: calcRem(10);
+
+
+// login-register settings
+$login-register-wrapper-margin: calcRem(30) auto calcRem(50);
+$login-register-section-title-spacing: calcRem(40);
+$login-register-section-title-border-bottom: 1px solid rgba($base-text-color, 0.2);
+$login-register-section-title-font-size: calcRem(42);
+$login-register-section-title-color: $brand-primary-color;
+$login-register-section-title-alignment: center;
+$login-register-single-input-wrapper-margin: calcRem(10) 0 calcRem(20);
+$login-register-label-font-size: calcRem(14);
+$login-register-input-padding: calcRem(10) calcRem(5);
+$login-register-input-border: 1px solid rgba($base-text-color, 0.4);
+$login-register-input-border-bottom: $login-register-input-border;
+$login-register-input-border-top: none;
+$login-register-input-border-left: none;
+$login-register-input-border-right: none;
+$login-register-hover-border-color: $brand-accent-color;
+$login-register-textarea-min-height: calcRem(100);
+$login-register-input-text-size: calcRem(14);
+$login-register-tip-text-color: rgba($base-text-color, 0.7);
+$login-register-tip-top-spacing: calcRem(10);
+$login-register-field-link-font-size: $login-register-input-text-size;
+$login-register-field-link-color: $brand-primary-color;
+$login-register-toggle-title-font-size: calcRem(20);
+$login-register-toggle-title-color: rgba($base-text-color, 0.7);
+
+
+// courseware
+
+$courseware-top-nav-top-margin: calcRem(10);
+$courseware-top-nav-bottom-margin: calcRem(20);
+
+$sequence-nav-bottom-padding: calcRem(16);
+$courseware-content-bottom-nav-width: 30%;
+
+$courseware-link-hover: "expanding-underline";  // can be "hover-pop", "expanding-underline", "brand-color" or "opacity"
+$courseware-content-font-size: 16px;
+$courseware-content-line-height: 20px;
+
+
+$hide-linked-accounts-tab: false;
+
+// new stuff
+$base-container-width: calcRem(1200);
+$base-learning-container-width: calcRem(1000);
+$courseware-content-container-side-padding: calcRem(100);
+$courseware-content-container-sidebar-width: calcRem(240);
+$courseware-content-container-width: $base-learning-container-width;
+$site-nav-width: $base-container-width;
+$inline-link-color: $brand-primary-color;
+$light-border-color: #dedede;
+$font-size-base-courseware: calcRem(18);
+$line-height-base-courseware: 200%;
+$in-app-container-border-radius: calcRem(15);
+$login-register-container-width: calcRem(480);

--- a/lms/static/sass/base/_site-config-variables-defaults.scss
+++ b/lms/static/sass/base/_site-config-variables-defaults.scss
@@ -1,0 +1,17 @@
+$primary_brand_color: #0090c1 !default;
+$buttons_accents_color: #0040f6 !default;
+$buttons_text_color: #fff !default;
+$text_color: #101010 !default;
+$selected_font: 'Roboto' !default;
+$header_logo_height: 90 !default;
+$header_font_size: 15 !default;
+$header_background_color: #fff !default;
+$header_text_color: #000 !default;
+$header_buttons_color: #0040f6 !default;
+$header_buttons_text_color: #fff !default;
+$footer_logo_height: 60 !default;
+$footer_font_size: 15 !default;
+$footer_background_color: #fff !default;
+$footer_text_color: #000 !default;
+$footer_links_color: #0040f8 !default;
+$footer_copyright_text_color: #000 !default;

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -41,6 +41,20 @@
     return get_value('THEME_VERSION', 'amc-v1')
 %>
 
+## get new config values
+
+<%!
+  def page_content_v2():
+    if get_theme_version():
+      return get_value('page', {})
+%>
+
+<%!
+  def site_setting_v2():
+    if get_theme_version():
+      return get_value('setting', {})
+%>
+
 
 ## =======================================================
 ## this template is used to define content to be displayed
@@ -51,9 +65,13 @@
 
 <%def name="get_global_settings()">
   <%
-  encoded_primary_font = urllib.parse.quote(get_value('primary-font', 'Roboto').encode('utf-8'))
-  encoded_accent_font = urllib.parse.quote(get_value('accent-font', 'Delius Unicase').encode('utf-8'))
-  latin_extended = "&amp;subset=latin-ext" if get_value('accent-font', False) else ""
+  if get_theme_version() == 'tahoe-v2':
+    encoded_primary_font = urllib.parse.quote(site_setting_v2().get('selected_font', 'Roboto').encode('utf-8'))
+    latin_extended = "&amp;subset=latin-ext"
+  else:
+    encoded_primary_font = urllib.parse.quote(get_value('primary-font', 'Roboto').encode('utf-8'))
+    encoded_accent_font = urllib.parse.quote(get_value('accent-font', 'Delius Unicase').encode('utf-8'))
+    latin_extended = "&amp;subset=latin-ext" if get_value('accent-font', False) else ""
 
   # Support for github.com/appsembler/tahoe-auth0
   is_tahoe_auth0_enabled = tahoe_auth0_helpers.is_tahoe_auth0_enabled()
@@ -64,34 +82,65 @@
     login_url = '/login'
 
 
-  return {
-    'enable_registration_button' : get_value('enable_registration_button', True),
-    'enable_registration_link_on_login' : get_value('enable_registration_link_on_login', True),
-    'enable_registration_form' : get_value('enable_registration_form', True),
-    'sso_disable_login_fields' : get_value('sso_disable_login_fields', False),
-    'fonts_url' : 'https://fonts.googleapis.com/css?family={}|{}:300,300i,400,400i,700,700i,900{}'.format(
-      encoded_accent_font, encoded_primary_font, latin_extended),
-    'apple_app_id' : '' if get_theme_version() == 'dashboard-v2 else 'something else',
-    'page_status': get_value('page_status', {}),
-    'course-catalogue_enabled': get_value('course-catalogue_enabled', True),
-    'enable_course_catalogue_for_non-auth_users': get_value('enable_course_catalogue_for_non-auth_users', True),
-    'appsembler_ga_code': "UA-18398802-14", ## need to enter correct one
-    'appsembler_lms_tracking_code': "UA-18398802-26", ## our new GA property
-    'client_ga_code': get_value('client_ga_code', ""),
-    'allow_search_engine_indexing': get_value('allow_search_engine_indexing', True),
-    'custom_site_meta_tags': get_value('site_seo_tags', []),
-    'combine_privacy_and_tos': get_value('combine_privacy_and_tos', False),
-    'enable_legacy_courseware_nav': get_value('enable_legacy_courseware_nav', True),
-    'customer_gtm_enabled': get_value('customer_gtm_enabled', False),
-    'customer_gtm_id': get_value('customer_gtm_id', ""),
-    'customer_gtm_enable_pii': get_value('customer_gtm_enable_pii', False),
-    'default_og_image': get_value('default_og_image', ''),
-    'og_image_use_course_images': get_value('og_image_use_course_images', ''),
-    'header_logo_target': get_value('header_logo_target', '/'),
-    'find_courses_dashboard_target': get_value('find_courses_dashboard_target', '/courses'),
-    'register_url': register_url,
-    'login_url': login_url,
-  }
+  if get_theme_version() == 'tahoe-v2':
+    return {
+      'enable_registration_button' : site_setting_v2().get('enable_site_nav_registration_button', True),
+      'enable_registration_link_on_login' : site_setting_v2().get('enable_site_registration_form', True),
+      'enable_registration_form' : site_setting_v2().get('enable_site_registration_form', True),
+      'sso_disable_login_fields' : site_setting_v2().get(False),
+      'fonts_url' : 'https://fonts.googleapis.com/css?family={}:300,300i,400,400i,700,700i,900{}'.format(
+        encoded_primary_font, latin_extended),
+      'apple_app_id' : '',
+      'page_status': site_setting_v2().get('page_editor_v1_pages_status', {}),
+      'course-catalogue_enabled': site_setting_v2().get('enable_course_catalogue', True),
+      'enable_course_catalogue_for_non-auth_users': site_setting_v2().get('display_course_catalogue_to_non_auth_users', True),
+      'appsembler_ga_code': "UA-18398802-14", ## need to enter correct one
+      'appsembler_lms_tracking_code': "UA-18398802-26", ## our new GA property
+      'client_ga_code': site_setting_v2().get('integrations_ga_code', ""),
+      'allow_search_engine_indexing': site_setting_v2().get('allow_search_engine_indexing', True),
+      'custom_site_meta_tags': site_setting_v2().get('site_seo_tags', []),
+      'combine_privacy_and_tos': site_setting_v2().get('combine_privacy_and_tos', False),
+      'enable_legacy_courseware_nav': site_setting_v2().get('enable_legacy_courseware_nav', True),
+      'customer_gtm_enabled': site_setting_v2().get('integrations_gtm_enabled', False),
+      'customer_gtm_id': site_setting_v2().get('integrations_gtm_id', ""),
+      'customer_gtm_enable_pii': site_setting_v2().get('integrations_gtm_enable_pii', False),
+      'default_og_image': site_setting_v2().get('og_image', ''),
+      'og_image_use_course_images': site_setting_v2().get('use_course_image_for_og', ''),
+      'header_logo_target': site_setting_v2().get('header_logo_target', '/'),
+      'find_courses_dashboard_target': site_setting_v2().get('find_courses_dashboard_target', '/courses'),
+      'register_url': register_url,
+      'login_url': login_url,
+    }
+  else:
+    return {
+      'enable_registration_button' : get_value('enable_registration_button', True),
+      'enable_registration_link_on_login' : get_value('enable_registration_link_on_login', True),
+      'enable_registration_form' : get_value('enable_registration_form', True),
+      'sso_disable_login_fields' : get_value('sso_disable_login_fields', False),
+      'fonts_url' : 'https://fonts.googleapis.com/css?family={}|{}:300,300i,400,400i,700,700i,900{}'.format(
+        encoded_accent_font, encoded_primary_font, latin_extended),
+      'apple_app_id' : '' if get_theme_version() == 'dashboard-v2 else 'something else',
+      'page_status': get_value('page_status', {}),
+      'course-catalogue_enabled': get_value('course-catalogue_enabled', True),
+      'enable_course_catalogue_for_non-auth_users': get_value('enable_course_catalogue_for_non-auth_users', True),
+      'appsembler_ga_code': "UA-18398802-14", ## need to enter correct one
+      'appsembler_lms_tracking_code': "UA-18398802-26", ## our new GA property
+      'client_ga_code': get_value('client_ga_code', ""),
+      'allow_search_engine_indexing': get_value('allow_search_engine_indexing', True),
+      'custom_site_meta_tags': get_value('site_seo_tags', []),
+      'combine_privacy_and_tos': get_value('combine_privacy_and_tos', False),
+      'enable_legacy_courseware_nav': get_value('enable_legacy_courseware_nav', True),
+      'customer_gtm_enabled': get_value('customer_gtm_enabled', False),
+      'customer_gtm_id': get_value('customer_gtm_id', ""),
+      'customer_gtm_enable_pii': get_value('customer_gtm_enable_pii', False),
+      'default_og_image': get_value('default_og_image', ''),
+      'og_image_use_course_images': get_value('og_image_use_course_images', ''),
+      'header_logo_target': get_value('header_logo_target', '/'),
+      'find_courses_dashboard_target': get_value('find_courses_dashboard_target', '/courses'),
+      'register_url': register_url,
+      'login_url': login_url,
+    }
+
   %>
 </%def>
 
@@ -100,21 +149,35 @@
 
 <%def name="get_brand_logos()">
   <%
-  return {
-    'logo_positive' : get_value('logo_positive') or static('images/branding/brand-logo.svg'), ## required
-    'logo_negative' : get_value('logo_negative') or static('images/branding/brand-logo-negative.svg'), ## required
-    'icon_color' : get_value('icon_color', '') or static('images/branding/icon-color.svg'), ## required
-    'icon_white' : get_value('icon_white', '') or static('images/branding/icon-white.svg'), ## required
-    'icon_black' : get_value('icon_black', '') or static('images/branding/icon-black.svg'), ## required
-  }
+  if get_theme_version() == 'tahoe-v2':
+    return {
+      'logo_positive' : site_setting_v2().get('site_branding_full_logo') or static('images/branding/brand-logo.svg'), ## required
+      'logo_negative' : site_setting_v2().get('site_branding_full_logo') or static('images/branding/brand-logo-negative.svg'), ## required
+      'icon_color' : site_setting_v2().get('site_branding_logo_icon_only', '') or static('images/branding/icon-color.svg'), ## required
+      'icon_white' : site_setting_v2().get('footer_logo', '') or static('images/branding/icon-white.svg'), ## required
+      'icon_black' : site_setting_v2().get('footer_logo', '') or static('images/branding/icon-black.svg'), ## required
+    }
+  else:
+    return {
+      'logo_positive' : get_value('logo_positive') or static('images/branding/brand-logo.svg'), ## required
+      'logo_negative' : get_value('logo_negative') or static('images/branding/brand-logo-negative.svg'), ## required
+      'icon_color' : get_value('icon_color', '') or static('images/branding/icon-color.svg'), ## required
+      'icon_white' : get_value('icon_white', '') or static('images/branding/icon-white.svg'), ## required
+      'icon_black' : get_value('icon_black', '') or static('images/branding/icon-black.svg'), ## required
+    }
   %>
 </%def>
 
 <%def name="get_brand_favicon()">
   <%
-  return {
-    'brand_favicon' : get_value('brand_favicon', '') or static('images/favicon.ico'),
-  }
+  if get_theme_version() == 'tahoe-v2':
+    return {
+      'brand_favicon' : site_setting_v2().get('site_branding_favicon', '') or static('images/favicon.ico'),
+    }
+  else:
+    return {
+      'brand_favicon' : get_value('brand_favicon', '') or static('images/favicon.ico'),
+    }
   %>
 </%def>
 
@@ -123,12 +186,18 @@
 
 <%def name="get_header_footer_templates()">
   <%
-  return {
-    'header_template' : '/design-templates/header/_header-appsembler-{}.html'.format(
-      get_current_site_configuration().get_page_content('header', {}).get('type', '01')), ## required
-    'footer_template' : '/design-templates/footer/_footer-appsembler-{}.html'.format(
-      get_current_site_configuration().get_page_content('footer', {}).get('type', '01')), ## required
-  }
+  if get_theme_version() == 'tahoe-v2':
+    return {
+      'header_template' : '/design-templates/header/_header-appsembler-01.html', ## required
+      'footer_template' : '/design-templates/footer/_footer-appsembler-01.html', ## required
+    }
+  else:
+    return {
+      'header_template' : '/design-templates/header/_header-appsembler-{}.html'.format(
+        get_current_site_configuration().get_page_content('header', {}).get('type', '01')), ## required
+      'footer_template' : '/design-templates/footer/_footer-appsembler-{}.html'.format(
+        get_current_site_configuration().get_page_content('footer', {}).get('type', '01')), ## required
+    }
   %>
 </%def>
 
@@ -137,7 +206,10 @@
 
 <%def name="get_header_menu_logged_out_extra_items()">
   <%
-    return get_current_site_configuration().get_page_content('header', {}).get('loggedOutItems', [])
+    if get_theme_version() == 'tahoe-v2':
+      return site_setting_v2().get('header_unauthenticated_items')
+    else:
+      return get_current_site_configuration().get_page_content('header', {}).get('loggedOutItems', [])
   %>
 </%def>
 
@@ -146,7 +218,10 @@
 
 <%def name="get_header_menu_logged_in_extra_items()">
   <%
-    return get_current_site_configuration().get_page_content('header', {}).get('loggedInItems', [])
+    if get_theme_version() == 'tahoe-v2':
+      return site_setting_v2().get('header_authenticated_items')
+    else:
+      return get_current_site_configuration().get_page_content('header', {}).get('loggedInItems', [])
   %>
 </%def>
 
@@ -155,7 +230,10 @@
 
 <%def name="get_footer_menu_items()">
   <%
-    return get_current_site_configuration().get_page_content('footer', {}).get('items', [])
+    if get_theme_version() == 'tahoe-v2':
+      return site_setting_v2().get('footer_menu_items')
+    else:
+      return get_current_site_configuration().get_page_content('footer', {}).get('items', [])
   %>
 </%def>
 
@@ -167,23 +245,41 @@
     footer_options = get_current_site_configuration().get_page_content('footer', {}).get('options', {})
 
     def _default_copyright():
-      return ugettext('{copy_sign} {year} {platform_name}. All rights reserved.').format(
-        copy_sign=u'©',
-        platform_name=force_text(get_value('PLATFORM_NAME', ugettext('Company Name'))),
-        year=date.today().strftime('%Y'),
-      )
+      if get_theme_version() == 'tahoe-v2':
+        return ugettext('{copy_sign} {year} {platform_name}. All rights reserved.').format(
+          copy_sign=u'©',
+          platform_name=force_text(get_value('site_name', ugettext('Company Name'))),
+          year=date.today().strftime('%Y'),
+        )
+      else:
+        return ugettext('{copy_sign} {year} {platform_name}. All rights reserved.').format(
+          copy_sign=u'©',
+          platform_name=force_text(get_value('PLATFORM_NAME', ugettext('Company Name'))),
+          year=date.today().strftime('%Y'),
+        )
 
     default_copyright = lazy(_default_copyright, six.text_type)
 
-    return {
-      'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
-      'footer_copyright_text' : translate(footer_options.get('footer_copyright_text'), default=default_copyright()),
-      'display_edx_disclaimer' : footer_options.get('display_edx_disclaimer', True), ## bool value required
-      'edx_disclaimer' : translate(footer_options.get('edx_disclaimer'), default=_('edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')),
-      'display_poweredby' : footer_options.get('display_poweredby', True), ## bool value required
-      'display_app_link' : footer_options.get('display_app_link', False),
-      'app_url' : footer_options.get('app_url', '')
-    }
+    if get_theme_version() == 'tahoe-v2':
+      return {
+        'footer_logo' : site_setting_v2().get('footer_logo', ''), ## leave as is, defined above. Can be changed to something custom if needed.
+        'footer_copyright_text' : translate(site_setting_v2().get('footer_copyright_text', ''), default=default_copyright()),
+        'display_edx_disclaimer' : site_setting_v2().get('display_footer_legal', True), ## bool value required
+        'edx_disclaimer' : translate(site_setting_v2().get('edx_disclaimer'), default=_('edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')),
+        'display_poweredby' : site_setting_v2().get('display_footer_powered_by', True), ## bool value required
+        'display_app_link' : False,
+        'app_url' : ''
+      }
+    else:
+      return {
+        'footer_logo' : get_brand_logos()['icon_black'], ## leave as is, defined above. Can be changed to something custom if needed.
+        'footer_copyright_text' : translate(footer_options.get('footer_copyright_text'), default=default_copyright()),
+        'display_edx_disclaimer' : footer_options.get('display_edx_disclaimer', True), ## bool value required
+        'edx_disclaimer' : translate(footer_options.get('edx_disclaimer'), default=_('edX, Open edX and the edX and Open edX logos are trademarks or registered trademarks of edX Inc.')),
+        'display_poweredby' : footer_options.get('display_poweredby', True), ## bool value required
+        'display_app_link' : footer_options.get('display_app_link', False),
+        'app_url' : footer_options.get('app_url', '')
+      }
   %>
 </%def>
 
@@ -192,7 +288,10 @@
 
 <%def name="get_index_content()">
   <%
-    return get_current_site_configuration().get_page_content('index', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('index', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('index', {}).get('content', [])
   %>
 </%def>
 
@@ -201,7 +300,10 @@
 
 <%def name="get_course_about_content()">
   <%
-    return get_current_site_configuration().get_page_content('course-about', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('course-about', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('course-about', {}).get('content', [])
   %>
 </%def>
 
@@ -210,7 +312,10 @@
 
 <%def name="get_course_catalogue_content()">
   <%
-    return get_current_site_configuration().get_page_content('courses', {}).get('content', [])
+  if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('courses', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('courses', {}).get('content', [])
   %>
 </%def>
 
@@ -255,7 +360,10 @@
 
 <%def name="get_faq_content()">
   <%
-    return get_current_site_configuration().get_page_content('faq', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('faq', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('faq', {}).get('content', [])
   %>
 </%def>
 
@@ -264,7 +372,10 @@
 
 <%def name="get_tos_content()">
   <%
-    return get_current_site_configuration().get_page_content('tos', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('tos', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('tos', {}).get('content', [])
   %>
 </%def>
 
@@ -273,7 +384,10 @@
 
 <%def name="get_copyright_content()">
   <%
-    return get_current_site_configuration().get_page_content('copyright', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('copyright', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('copyright', {}).get('content', [])
   %>
 </%def>
 
@@ -282,7 +396,10 @@
 
 <%def name="get_about_content()">
   <%
-    return get_current_site_configuration().get_page_content('about', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('about', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('about', {}).get('content', [])
   %>
 </%def>
 
@@ -291,7 +408,10 @@
 
 <%def name="get_help_content()">
   <%
-    return get_current_site_configuration().get_page_content('help', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('help', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('help', {}).get('content', [])
   %>
 </%def>
 
@@ -300,7 +420,10 @@
 
 <%def name="get_contact_content()">
   <%
-    return get_current_site_configuration().get_page_content('contact', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('contact', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('contact', {}).get('content', [])
   %>
 </%def>
 
@@ -308,7 +431,10 @@
 
 <%def name="get_blog_content()">
   <%
-    return get_current_site_configuration().get_page_content('blog', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('blog', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('blog', {}).get('content', [])
   %>
 </%def>
 
@@ -316,7 +442,10 @@
 
 <%def name="get_donate_content()">
   <%
-    return get_current_site_configuration().get_page_content('donate', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('donate', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('donate', {}).get('content', [])
   %>
 </%def>
 
@@ -324,7 +453,10 @@
 
 <%def name="get_honor_content()">
   <%
-    return get_current_site_configuration().get_page_content('honor', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('honor', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('honor', {}).get('content', [])
   %>
 </%def>
 
@@ -332,7 +464,10 @@
 
 <%def name="get_jobs_content()">
   <%
-    return get_current_site_configuration().get_page_content('jobs', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('jobs', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('jobs', {}).get('content', [])
   %>
 </%def>
 
@@ -340,7 +475,10 @@
 
 <%def name="get_news_content()">
   <%
-    return get_current_site_configuration().get_page_content('news', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('news', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('news', {}).get('content', [])
   %>
 </%def>
 
@@ -348,7 +486,10 @@
 
 <%def name="get_press_content()">
   <%
-    return get_current_site_configuration().get_page_content('press', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('press', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('press', {}).get('content', [])
   %>
 </%def>
 
@@ -356,7 +497,10 @@
 
 <%def name="get_privacy_content()">
   <%
-    return get_current_site_configuration().get_page_content('privacy', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('privacy', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('privacy', {}).get('content', [])
   %>
 </%def>
 
@@ -364,7 +508,10 @@
 
 <%def name="get_embargo_content()">
   <%
-    return get_current_site_configuration().get_page_content('embargo', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('embargo', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('embargo', {}).get('content', [])
   %>
 </%def>
 
@@ -372,7 +519,10 @@
 
 <%def name="get_tracks_content()">
   <%
-    return get_current_site_configuration().get_page_content('tracks', {}).get('content', [])
+    if get_theme_version() == 'tahoe-v2':
+      return page_content_v2().get('tracks', {}).get('content', [])
+    else:
+      return get_current_site_configuration().get_page_content('tracks', {}).get('content', [])
   %>
 </%def>
 
@@ -380,37 +530,62 @@
 
 <%def name="get_certificates_settings(course_context={})">
   <%
-  cert_settings = {
-    'paper_orientation': get_value('certificates', {}).get('paper_orientation', 'landscape'),
-    'header_logo': get_value('certificates', {}).get('header_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
-    'header_logo_width': get_value('certificates', {}).get('header_logo_width', '240px'),
-    'cert_logo': get_value('certificates', {}).get('cert_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
-    'logo_width': get_value('certificates', {}).get('cert_logo_width', '160px'),
-    'platform_name_amc': translate(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', '')), default=_('Platform Name')),
-    'certificate_banner_text': translate(get_value('certificates', {}).get('certificate_banner_text', course_context.get('document_banner', ''))),
-    'header_text': translate(get_value('certificates', {}).get('header_text', ''), default=_('Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
-    'short_platform_description': translate(get_value('certificates', {}).get('short_platform_description', '')),
-    'we_hereby_text': translate(get_value('certificates', {}).get('we_hereby_text', ''), default=_('We hereby certify that:')),
-    'successfully_completed_text': translate(get_value('certificates', {}).get('successfully_completed_text', ''), default=_('successfully completed, received a passing grade, and was awarded this platform\'s Honor Code Certificate of Completion in:')),
-    'optional_cert_text': translate(get_value('certificates', {}).get('optional_cert_text', '')),
-    'footer_about_platform_text': translate(get_value('certificates', {}).get('footer_about_platform_text'), default=_('Our platform offers interactive online classes and MOOCs.')),
-    'footer_about_platform_url': get_value('certificates', {}).get('footer_about_platform_url', '#'),
-    'footer_about_accomplishments_text': translate(get_value('certificates', {}).get('footer_about_accomplishments_text'), default=_('Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.')),
-    'footer_copyright_text': translate(get_value('certificates', {}).get('footer_copyright_text', "")),
-    'footer_tos_url': get_value('certificates', {}).get('footer_tos_url', "#"),
-    'footer_privacy_url': get_value('certificates', {}).get('footer_privacy_url', "#"),
-    'accomplishment_icon': get_value('certificates', {}).get('cert_accomplishment_icon', ''),
-    'accomplishment_icon_width': get_value('certificates', {}).get('cert_accomplishment_icon_width', '60px'),
-    'certificate_custom_org_name': translate(get_value('certificates', {}).get('certificate_custom_org_name', "")),
-    'certificate_show_url': get_value('certificates', {}).get('certificate_show_url', True),
-  }
+    if get_theme_version() == 'tahoe-v2':
+      cert_settings = {
+        'paper_orientation': site_setting_v2().get('certificates_certificate_orientation', 'landscape'),
+        'header_logo': site_setting_v2().get('certificates_certificate_header_area_logo', site_setting_v2().get('site_branding_full_logo', static('images/branding/brand-logo.svg'))),
+        'header_logo_width': site_setting_v2().get('certificates_certificate_header_area_logo_width', '240px'),
+        'cert_logo': site_setting_v2().get('certificates_certificate_logo_on_certificate', site_setting_v2().get('site_branding_full_logo', static('images/branding/brand-logo.svg'))),
+        'logo_width': site_setting_v2().get('certificates_certificate_logo_on_certificate_width', '160px'),
+        'platform_name_amc': translate(site_setting_v2().get('certificates_certificate_platform_name', site_setting_v2().get('site_title', '')), default=_('Platform Name')),
+        'certificate_banner_text': translate(('certificate_banner_text', course_context.get('document_banner', ''))),
+        'header_text': translate(site_setting_v2().get('certificates_certificate_page_message', ''), default=_('Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
+        'short_platform_description': translate(site_setting_v2().get('certificates_short_platform_description', '')),
+        'we_hereby_text': translate(site_setting_v2().get('certificates_we_hereby_text', ''), default=_('We hereby certify that:')),
+        'successfully_completed_text': translate(site_setting_v2().get('certificates_successfully_completed_text', ''), default=_('successfully completed, received a passing grade, and was awarded this platform\'s Honor Code Certificate of Completion in:')),
+        'optional_cert_text': translate(site_setting_v2().get('certificates_optional_certificate_text', '')),
+        'footer_about_platform_text': translate(site_setting_v2().get('certificates_about_platform_text'), default=_('Our platform offers interactive online classes and MOOCs.')),
+        'footer_about_platform_url': site_setting_v2().get('certificates_learn_more_about_platform_url', '#'),
+        'footer_about_accomplishments_text': translate(site_setting_v2().get('certificates_about_accomplishments_text'), default=_('Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.')),
+        'footer_copyright_text': translate(site_setting_v2().get('certificates_footer_copyright_text', "")),
+        'footer_tos_url': site_setting_v2().get('certificates_tos_url', "#"),
+        'footer_privacy_url': site_setting_v2().get('certificates_privacy_policy_url', "#"),
+        'accomplishment_icon': site_setting_v2().get('certificates_accomplishment_icon_on_certificate', ''),
+        'accomplishment_icon_width': site_setting_v2().get('certificates_accomplishment_icon_on_certificate_width', '60px'),
+        'certificate_custom_org_name': translate(site_setting_v2().get('certificates_certificate_custom_organization', "")),
+        'certificate_show_url': site_setting_v2().get('certificates_show_certificate_url', True),
+      }
+    else:
+      cert_settings = {
+        'paper_orientation': get_value('certificates', {}).get('paper_orientation', 'landscape'),
+        'header_logo': get_value('certificates', {}).get('header_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
+        'header_logo_width': get_value('certificates', {}).get('header_logo_width', '240px'),
+        'cert_logo': get_value('certificates', {}).get('cert_logo', get_value('logo_positive', static('images/branding/brand-logo.svg'))),
+        'logo_width': get_value('certificates', {}).get('cert_logo_width', '160px'),
+        'platform_name_amc': translate(get_value('certificates', {}).get('platform_name', get_value('PLATFORM_NAME', '')), default=_('Platform Name')),
+        'certificate_banner_text': translate(get_value('certificates', {}).get('certificate_banner_text', course_context.get('document_banner', ''))),
+        'header_text': translate(get_value('certificates', {}).get('header_text', ''), default=_('Congratulations! This page summarizes what you accomplished. Show it off to family, friends, and colleagues in your social and professional networks.')),
+        'short_platform_description': translate(get_value('certificates', {}).get('short_platform_description', '')),
+        'we_hereby_text': translate(get_value('certificates', {}).get('we_hereby_text', ''), default=_('We hereby certify that:')),
+        'successfully_completed_text': translate(get_value('certificates', {}).get('successfully_completed_text', ''), default=_('successfully completed, received a passing grade, and was awarded this platform\'s Honor Code Certificate of Completion in:')),
+        'optional_cert_text': translate(get_value('certificates', {}).get('optional_cert_text', '')),
+        'footer_about_platform_text': translate(get_value('certificates', {}).get('footer_about_platform_text'), default=_('Our platform offers interactive online classes and MOOCs.')),
+        'footer_about_platform_url': get_value('certificates', {}).get('footer_about_platform_url', '#'),
+        'footer_about_accomplishments_text': translate(get_value('certificates', {}).get('footer_about_accomplishments_text'), default=_('Our platform acknowledges achievements through certificates, which are awarded for course activities that our platform students complete.')),
+        'footer_copyright_text': translate(get_value('certificates', {}).get('footer_copyright_text', "")),
+        'footer_tos_url': get_value('certificates', {}).get('footer_tos_url', "#"),
+        'footer_privacy_url': get_value('certificates', {}).get('footer_privacy_url', "#"),
+        'accomplishment_icon': get_value('certificates', {}).get('cert_accomplishment_icon', ''),
+        'accomplishment_icon_width': get_value('certificates', {}).get('cert_accomplishment_icon_width', '60px'),
+        'certificate_custom_org_name': translate(get_value('certificates', {}).get('certificate_custom_org_name', "")),
+        'certificate_show_url': get_value('certificates', {}).get('certificate_show_url', True),
+      }
+    # Support override per-course via cert_html_view_overrides Advanced Setting.
+    # Note: None of the variables defined in get_certificate_settings and used in our
+    # custom certificate template are the original variables passed in context from
+    # certificates.views.webview.
+    cert_settings.update(course_context)
 
-  # Support override per-course via cert_html_view_overrides Advanced Setting.
-  # Note: None of the variables defined in get_certificate_settings and used in our
-  # custom certificate template are the original variables passed in context from
-  # certificates.views.webview.
-  cert_settings.update(course_context)
-
-  return cert_settings
+    return cert_settings
   %>
 </%def>

--- a/lms/templates/theme-variables.html
+++ b/lms/templates/theme-variables.html
@@ -36,6 +36,11 @@
 %></%def>
 
 
+<%!
+  def get_theme_version():
+    return get_value('THEME_VERSION', 'amc-v1')
+%>
+
 
 ## =======================================================
 ## this template is used to define content to be displayed
@@ -58,6 +63,7 @@
   else:
     login_url = '/login'
 
+
   return {
     'enable_registration_button' : get_value('enable_registration_button', True),
     'enable_registration_link_on_login' : get_value('enable_registration_link_on_login', True),
@@ -65,7 +71,7 @@
     'sso_disable_login_fields' : get_value('sso_disable_login_fields', False),
     'fonts_url' : 'https://fonts.googleapis.com/css?family={}|{}:300,300i,400,400i,700,700i,900{}'.format(
       encoded_accent_font, encoded_primary_font, latin_extended),
-    'apple_app_id' : '',
+    'apple_app_id' : '' if get_theme_version() == 'dashboard-v2 else 'something else',
     'page_status': get_value('page_status', {}),
     'course-catalogue_enabled': get_value('course-catalogue_enabled', True),
     'enable_course_catalogue_for_non-auth_users': get_value('enable_course_catalogue_for_non-auth_users', True),


### PR DESCRIPTION
## Change description

**Important: This PR is closely tied with the sibling PR in the `edx-theme-codebase` repo ([https://github.com/appsembler/edx-theme-codebase/pull/188](https://github.com/appsembler/edx-theme-codebase/pull/188)).**

### Background
We moved to a new version of site configurations, where we don't store them into the LMS, but we use our own service. Along with this change (which is quite fundamental itself), we also have modifications to variable names, some variables being dropped, etc. Since we want to have a gradual transition period, we need the system to work in a hybrid approach - with both old and new approach working with the same codebase. We handle this in two key areas:

### Theme variables
We check whether the site configuration is returning the config version to be the new one. If so, then we use one type of return mappings. If it's the old one, return same as before.

### SASS variables
This was a bit more tricky. The soltion is that we introduce another entry file for the compiler: `main-v2.scss`. This file has slightly different imports. Old system would basically load the stored SASS variables and their values from edx site config, then create a "file" out of them and replace the import of `_branding-basics.scss` file with that. This new one has a slightly modified approach:
- do the same thing, but now some new variables and variable names will be loaded
- we previously had issues if some variable was missing. No fallback. Now after the inital file where we load the variables from the site configuration we load another file called `_site-config-variables-defaults.scss`. This one has all the possible variables that are crucial to the compiler with their defaults and denoted with `!default`. What this tells the SASS compiler is "if this variable _was not declared before this moment_, this is the declaration for that variable. otherwise leave it as is"
- then we finally load a file called `_site-config-variables-adapter.scss`. It's essentially a copy of the content that the old `branding-basics` file used to have, but here we assign values of our new variables to them. Essentially keeping the rest of the theme and its SASS files intact so they still work with the old system.

### NOTE:
@OmarIthawi I saw that you still use much of the old system. This part **will break**: https://github.com/appsembler/edx-platform/blob/ee287d60196461f85b65b35a3c0888b3154a6350/openedx/core/djangoapps/site_configuration/models.py#L322
The new values of SASS variables are **not** in the form of `$var_name: [compiled, raw]`. It's just `$variable: raw`. You need different returns for old/new. Also that is **if** that is the return from the site config service. If it's the full thing, then it's more like: `'$var_name': { value: 'raw', ... }`

### ANOTHER NOTE:
This code is untested. I have no way of testing it. So it's a YOLO at this point - be warned!
**LEEEROY JENKINS**


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
