### PR TITLE
Fix certificate logo URL - RED-2860

### DIFF
--- a/lms/templates/certificates/_accomplishment-header.html
+++ b/lms/templates/certificates/_accomplishment-header.html
@@ -6,7 +6,7 @@
 
     <header class="header-app" role="banner">
         <h1 class="header-app-title">
-            <a class="logo" href="${request.site}" style="width: auto;">
+            <a class="logo" href="/" style="width: auto;">
                 <img class="a--accomplishment--header-logo" style="width: ${get_certificates_settings()['header_logo_width']}; height: auto;" src="${get_certificates_settings()['header_logo']}" alt="${get_certificates_settings()['platform_name_amc']}" />
             </a>
             <span class="sr-only">${get_certificates_settings()['platform_name_amc']}</span>


### PR DESCRIPTION
## Change description

Fix certificate logo URL - RED-2860 . The link is using `request.site` which contains `<domain>` without https schema. Therefore; the link is interpreted as `https://<domain>/certificates/course/<domain>`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/RED-2860

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
