### PR TITLE
Obey the no grading advanced course setting

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -26,7 +26,6 @@ from openedx.core.djangoapps.appsembler.html_certificates.helpers import get_cou
 from openedx.core.djangoapps.content.block_structure.api import get_block_structure_manager
 from lms.djangoapps.grades.api import CourseGradeFactory
 from xmodule.modulestore.django import modulestore
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from lms.djangoapps.courseware.courses import get_course_with_access
 %>
 

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -26,6 +26,8 @@ from openedx.core.djangoapps.appsembler.html_certificates.helpers import get_cou
 from openedx.core.djangoapps.content.block_structure.api import get_block_structure_manager
 from lms.djangoapps.grades.api import CourseGradeFactory
 from xmodule.modulestore.django import modulestore
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from lms.djangoapps.courseware.courses import get_course_with_access
 %>
 
 <%
@@ -180,6 +182,7 @@ from xmodule.modulestore.django import modulestore
 
           <!-- Newly added progress/grading display for course -->
           <%
+            course = get_course_with_access(user, 'load', enrollment.course_id)
             completion_summary = get_course_blocks_completion_summary(enrollment.course_id, user)
             collected_block_structure = get_block_structure_manager(enrollment.course_id).get_collected()
             descriptor = modulestore().get_course(enrollment.course_id)
@@ -203,16 +206,18 @@ from xmodule.modulestore.django import modulestore
                 </div>
               </div>
             </div>
-            <div class="grading-details">
-              <div>
-                <span class="details-title">Course grade</span>
-                % if course_grade.passed:
-                  <p class="larger-paragraph">You have passed this course and obtained the <strong>${course_grade.letter_grade}</strong> grade.</p>
-                % else:
-                  <p><em>The grade cutoff for passing this course is ${round(grade_cutoff_percent, 0)}%. You have not passed this course yet. Your current weighted grade is <strong>${course_grade.percent}%</strong></em></p>
-                % endif
+            % if not course.no_grade:
+              <div class="grading-details">
+                <div>
+                  <span class="details-title">Course grade</span>
+                  % if course_grade.passed:
+                    <p class="larger-paragraph">You have passed this course and obtained the <strong>${course_grade.letter_grade}</strong> grade.</p>
+                  % else:
+                    <p><em>The grade cutoff for passing this course is ${round(grade_cutoff_percent, 0)}%. You have not passed this course yet. Your current weighted grade is <strong>${course_grade.percent}%</strong></em></p>
+                  % endif
+                </div>
               </div>
-            </div>
+            % endif
           </div>
 
         </div>


### PR DESCRIPTION
## Change description

Our updated course display on Learner Dashboard still showed the grading information even when a course had grading disabled in Advanced Settings for a course in Studio. This fixes the issue.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
