### PR TITLE
more fixes for grade letters

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -192,7 +192,7 @@ from lms.djangoapps.courseware.courses import get_course_with_access
                 grade_cutoff_percent = str(grading_policy['GRADE_CUTOFFS']['Pass']*100) + "%"
               else:
                 sorted_cutoff = OrderedDict(sorted(grading_policy['GRADE_CUTOFFS'].items()))
-                grade_cutoff_letters = ', '.join(['{}: {}%'.format(k,(round(float(v)*100))) for k,v in sorted_cutoff.items()])
+                grade_cutoff_percent = ', '.join(['{}: {}%'.format(k,(round(float(v)*100))) for k,v in sorted_cutoff.items()])
 
             else:
               grade_cutoff_percent = 0

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -2,6 +2,7 @@
 
 <%!
 import six
+from collections import OrderedDict
 
 from django.utils.http import urlencode, urlquote_plus
 from django.utils.translation import ugettext as _
@@ -187,10 +188,12 @@ from lms.djangoapps.courseware.courses import get_course_with_access
             descriptor = modulestore().get_course(enrollment.course_id)
             grading_policy = descriptor.grading_policy
             if grading_policy.get('GRADE_CUTOFFS', False):
-              if grading_policy['GRADE_CUTOFFS'].has_key('Pass'):
-                grade_cutoff_percent = grading_policy['GRADE_CUTOFFS']['Pass']*100
+              if grading_policy['GRADE_CUTOFFS'].get('Pass', False):
+                grade_cutoff_percent = str(grading_policy['GRADE_CUTOFFS']['Pass']*100) + "%"
               else:
-                grade_cutoff_percent = ", ".join(f"{key}: {round(val*100)}" for key, val in grading_policy['GRADE_CUTOFFS'].items())
+                sorted_cutoff = OrderedDict(sorted(grading_policy['GRADE_CUTOFFS'].items()))
+                grade_cutoff_letters = ', '.join(['{}: {}%'.format(k,(round(float(v)*100))) for k,v in sorted_cutoff.items()])
+
             else:
               grade_cutoff_percent = 0
             course_grade = CourseGradeFactory().read(user, collected_block_structure=collected_block_structure)
@@ -211,14 +214,14 @@ from lms.djangoapps.courseware.courses import get_course_with_access
                 </div>
               </div>
             </div>
-            % if not (course.no_grade or (grade_cutoff_percent == 0)):
+            % if not (course.no_grade):
               <div class="grading-details">
                 <div>
                   <span class="details-title">Course grade</span>
                   % if course_grade.passed:
                     <p class="larger-paragraph">You have passed this course and obtained the <strong>${course_grade.letter_grade}</strong> grade.</p>
                   % else:
-                    <p><em>The grade cutoff for passing this course is ${round(grade_cutoff_percent, 0)}%. You have not passed this course yet. Your current weighted grade is <strong>${course_grade.percent * 100}%</strong></em></p>
+                    <p><em>The grade cutoff for passing this course is ${grade_cutoff_percent}. You have not passed this course yet. Your current weighted grade is <strong>${course_grade.percent * 100}%</strong></em></p>
                   % endif
                 </div>
               </div>


### PR DESCRIPTION
## Change description

When people uses Letters for grading in courses instead of just pass / fail, the grade output becomes more complex. We need to display the letters instead off the `Pass` value, which is missing in the output.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
