### PR TITLE
Use get_course_by_id to fix RED-3118

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -27,7 +27,7 @@ from openedx.core.djangoapps.appsembler.html_certificates.helpers import get_cou
 from openedx.core.djangoapps.content.block_structure.api import get_block_structure_manager
 from lms.djangoapps.grades.api import CourseGradeFactory
 from xmodule.modulestore.django import modulestore
-from lms.djangoapps.courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_by_id
 %>
 
 <%
@@ -182,7 +182,7 @@ from lms.djangoapps.courseware.courses import get_course_with_access
 
           <!-- Newly added progress/grading display for course -->
           <%
-            course = get_course_with_access(user, 'load', enrollment.course_id)
+            course = get_course_by_id(enrollment.course_id)
             completion_summary = get_course_blocks_completion_summary(enrollment.course_id, user)
             collected_block_structure = get_block_structure_manager(enrollment.course_id).get_collected()
             descriptor = modulestore().get_course(enrollment.course_id)


### PR DESCRIPTION
## Change description

Since the template `lms/templates/dashboard/_dashboard_course_listing.html` is using `enrollment` variable that is already checked by `get_course_with_access` then we can safely call `get_course_by_id` instead in this template. This is to resolve the redirect issue in [RED-3118](https://appsembler.atlassian.net/browse/RED-3118)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fixes: https://appsembler.atlassian.net/browse/RED-3118

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
