### PR TITLE
Fix a bug in extra JS rendering

### DIFF
--- a/lms/templates/footer-extra.html
+++ b/lms/templates/footer-extra.html
@@ -9,7 +9,12 @@
 <!-- Custom base JavaScript -->
 <script src="${static('js/base.js')}"></script>
 
-${get_global_settings().get('default_additional_site_foot_content', '')}
-% if request.COOKIES.get('cookieconsent_status', '') == 'dismiss':
-  ${get_global_settings().get('cookie_accepted_additional_site_foot_content', '')}
+% if get_global_settings().get('default_additional_site_foot_content', ''):
+  ${get_global_settings().get('default_additional_site_foot_content')}
+% endif
+
+% if get_global_settings().get('cookie_accepted_additional_site_foot_content', ''):
+  % if request.COOKIES.get('cookieconsent_status', '') == 'dismiss':
+    ${get_global_settings().get('cookie_accepted_additional_site_foot_content')}
+  % endif
 % endif

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -63,7 +63,12 @@
   <!-- /Google Analytics code -->
 % endif
 
-${get_global_settings().get('default_additional_site_head_content', '')}
-% if request.COOKIES.get('cookieconsent_status', '') == 'dismiss':
-  ${get_global_settings().get('cookie_accepted_additional_site_head_content', '')}
+% if get_global_settings().get('default_additional_site_head_content', ''):
+  ${get_global_settings().get('default_additional_site_head_content')}
+% endif
+
+% if get_global_settings().get('cookie_accepted_additional_site_head_content', ''):
+  % if request.COOKIES.get('cookieconsent_status', '') == 'dismiss':
+    ${get_global_settings().get('cookie_accepted_additional_site_head_content')}
+  % endif
 % endif


### PR DESCRIPTION
## Change description

Bug was that if no extra JS is defined in site config, it would render weird `{}` at top and bottom of page.
This hopefully fixes it.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
