### PR TITLE
Use original course locators instead of enrollment ones

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -69,14 +69,14 @@ from lms.djangoapps.courseware.access import has_access
           lang="${course_overview.language}"
         % endif
       >
-<article class="course${mode_class}" aria-labelledby="course-title-${enrollment.course_id}" id="course-card-${course_card_index}">
+<article class="course${mode_class}" aria-labelledby="course-title-${course_overview.id}" id="course-card-${course_card_index}">
   <% course_target = reverse(course_home_url_name(course_overview.id), args=[six.text_type(course_overview.id)]) %>
-  <section class="details" aria-labelledby="details-heading-${enrollment.course_id}">
-      <h2 class="hd hd-2 sr" id="details-heading-${enrollment.course_id}">${_('Course details')}</h2>
+  <section class="details" aria-labelledby="details-heading-${course_overview.id}">
+      <h2 class="hd hd-2 sr" id="details-heading-${course_overview.id}">${_('Course details')}</h2>
     <div class="wrapper-course-image" aria-hidden="true">
       % if show_courseware_link and not is_unfulfilled_entitlement:
         % if not is_course_blocked and not is_course_expired:
-            <a href="${course_target}" data-course-key="${enrollment.course_id}" class="cover course-target-link" tabindex="-1">
+            <a href="${course_target}" data-course-key="${course_overview.id}" class="cover course-target-link" tabindex="-1">
               <img src="${course_overview.image_urls['small']}" class="course-image" alt="${_('{course_number} {course_name} Home Page').format(course_number=course_overview.number, course_name=course_overview.display_name_with_default)}" />
             </a>
         % else:
@@ -100,12 +100,12 @@ from lms.djangoapps.courseware.access import has_access
       % endif
     </div>
       <div class="wrapper-course-details">
-        <h3 class="course-title" id="course-title-${enrollment.course_id}">
+        <h3 class="course-title" id="course-title-${course_overview.id}">
           % if show_courseware_link and not is_unfulfilled_entitlement:
             % if not is_course_blocked and not is_course_expired:
-              <a data-course-key="${enrollment.course_id}" href="${course_target}" class="course-target-link">${course_overview.display_name_with_default}</a>
+              <a data-course-key="${course_overview.id}" href="${course_target}" class="course-target-link">${course_overview.display_name_with_default}</a>
             % else:
-              <a class="disable-look" data-course-key="${enrollment.course_id}">${course_overview.display_name_with_default}</a>
+              <a class="disable-look" data-course-key="${course_overview.id}">${course_overview.display_name_with_default}</a>
             % endif
           % else:
             <span>${course_overview.display_name_with_default}</span>
@@ -140,7 +140,7 @@ from lms.djangoapps.courseware.access import has_access
 
             <span class="info-date-block-container">
                 % if not is_unfulfilled_entitlement and is_course_expired:
-                  <span class="info-date-block" data-course-key="${enrollment.course_id}">
+                  <span class="info-date-block" data-course-key="${course_overview.id}">
                     ${show_courseware_link.user_message}
                     <span class="sr">
                       &nbsp;${_('for {course_display_name}').format(course_display_name=course_overview.display_name_with_default)}
@@ -183,10 +183,10 @@ from lms.djangoapps.courseware.access import has_access
 
           <!-- Newly added progress/grading display for course -->
           <%
-            if not (user.userorganizationmapping_set.first().is_amc_admin or has_access(user, 'staff', enrollment.course_id)):
-              course = get_course_by_id(enrollment.course_id, depth=1)
+            if not (user.userorganizationmapping_set.first().is_amc_admin or has_access(user, 'staff', course_overview.id)):
+              course = get_course_by_id(course_overview.id, depth=1)
               try:
-                completion_summary = get_course_blocks_completion_summary(enrollment.course_id, user)
+                completion_summary = get_course_blocks_completion_summary(course_overview.id, user)
               except Exception:
                 completion_summary = {
                   'complete_count': 0,
@@ -197,8 +197,8 @@ from lms.djangoapps.courseware.access import has_access
                 completion_percent = 100 * float(completion_summary['complete_count'])/total_completion_units
               else:
                   completion_percent = 0
-              collected_block_structure = get_block_structure_manager(enrollment.course_id).get_collected()
-              descriptor = modulestore().get_course(enrollment.course_id)
+              collected_block_structure = get_block_structure_manager(course_overview.id).get_collected()
+              descriptor = modulestore().get_course(course_overview.id)
               grading_policy = descriptor.grading_policy
               if grading_policy.get('GRADE_CUTOFFS', False):
                 if grading_policy['GRADE_CUTOFFS'].get('Pass', False):
@@ -217,7 +217,7 @@ from lms.djangoapps.courseware.access import has_access
                 <span class="details-title">Course completion</span>
               </div>
               <div class="completion-graph-container">
-                % if user.userorganizationmapping_set.first().is_amc_admin or has_access(user, 'staff', enrollment.course_id):
+                % if user.userorganizationmapping_set.first().is_amc_admin or has_access(user, 'staff', course_overview.id):
                   <span class="completion-current-value" style="font-weight:normal; opacity:0.7"><em>Not available for staff users</em></span>
                 % else:
                   <span class="completion-current-value">${round(completion_percent, 1)}%</span>
@@ -227,7 +227,7 @@ from lms.djangoapps.courseware.access import has_access
                 % endif
               </div>
             </div>
-            % if user.userorganizationmapping_set.first().is_amc_admin or has_access(user, 'staff', enrollment.course_id):
+            % if user.userorganizationmapping_set.first().is_amc_admin or has_access(user, 'staff', course_overview.id):
               <div class="grading-details">
                 <div>
                   <span class="details-title">Course grade</span>
@@ -256,9 +256,9 @@ from lms.djangoapps.courseware.access import has_access
             % if (show_courseware_link or is_unfulfilled_entitlement) and not is_course_expired:
               % if course_overview.has_ended():
                 % if is_course_blocked:
-                    <a class="enter-course-blocked archived course-target-link" data-course-key="${enrollment.course_id}">${_('View Archived Course')}<span class="sr">&nbsp;${course_overview.display_name_with_default}</span></a>
+                    <a class="enter-course-blocked archived course-target-link" data-course-key="${course_overview.id}">${_('View Archived Course')}<span class="sr">&nbsp;${course_overview.display_name_with_default}</span></a>
                 % elif not is_unfulfilled_entitlement:
-                  <a href="${course_target}" class="enter-course archived course-target-link" data-course-key="${enrollment.course_id}">${_('View Archived Course')}<span class="sr">&nbsp;${course_overview.display_name_with_default}</span></a>
+                  <a href="${course_target}" class="enter-course archived course-target-link" data-course-key="${course_overview.id}">${_('View Archived Course')}<span class="sr">&nbsp;${course_overview.display_name_with_default}</span></a>
                 % endif
 
               % else:
@@ -328,7 +328,7 @@ from lms.djangoapps.courseware.access import has_access
             % if entitlement and (can_refund_entitlement or show_email_settings):
                 <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, show_email_settings=show_email_settings'/>
             % elif not entitlement:
-                <div class="wrapper-action-more" data-course-key="${enrollment.course_id}">
+                <div class="wrapper-action-more" data-course-key="${course_overview.id}">
           <!-- logic added to show gear button if can_unenroll or show_email_settings -->
               % if can_unenroll or show_email_settings:
                   <button type="button" class="action action-more" id="actions-dropdown-link-${dashboard_index}" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-${dashboard_index}" data-course-number="${course_overview.number}" data-course-name="${course_overview.display_name_with_default}" data-dashboard-index="${dashboard_index}">
@@ -525,7 +525,7 @@ from lms.djangoapps.courseware.access import has_access
                         line_break=HTML('<br>'),
                         link_start=HTML('<a href="{}" class="verified-info" data-course-key="{}">').format(
                           marketing_link('WHAT_IS_VERIFIED_CERT'),
-                          enrollment.course_id
+                          course_overview.id
                         ),
                         link_end=HTML('</a>'),
                         cert_name_long=cert_name_long


### PR DESCRIPTION
## Change description

Use original course locators instead of enrollment ones. The issue is that `enrollment.course_id` is not always a valid course locator. For example we can have `course-v1:org-theorg01-2022-07` in `enrollment.course_id` instead of the correct `course-v1:org-THEORG01-2022-07` as in `enrollment.course.id`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fixes: https://appsembler.atlassian.net/browse/RED-3141

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
