### PR TITLE
refactor js code so mako doesnt interpret it

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -81,8 +81,9 @@
 <!-- Add JavaScript for handling the Preview Environment -->
 <script defer>
   function getCookie(name) {
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
+    const value = '; ' + document.cookie;
+    const splitParam = '; ' + name + '=';
+    const parts = value.split(splitParam);
     if (parts.length === 2) return parts.pop().split(';').shift();
   }
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Change description

Mako and JS use same syntax for concatenation of variables. Caused a doo doo.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
