### PR TITLE
support Tahoe 2.0 sites for certs

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -7,7 +7,8 @@
   from django.urls import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
-  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+  from cms.djangoapps.appsembler.certificates_helpers import is_certificates_enabled_for_course_site
 %>
 <div class="wrapper-header wrapper" id="view-top">
   <header class="primary" role="banner">
@@ -21,7 +22,6 @@
       <%
             course_key = context_course.id
             url_encoded_course_key = quote(six.text_type(course_key).encode('utf-8'), safe='')
-            current_organization = context_course.org
             index_url = reverse('course_handler', kwargs={'course_key_string': six.text_type(course_key)})
             course_team_url = reverse('course_team_handler', kwargs={'course_key_string': six.text_type(course_key)})
             assets_url = reverse('assets_handler', kwargs={'course_key_string': six.text_type(course_key)})
@@ -35,7 +35,7 @@
             advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
             tabs_url = reverse('tabs_handler', kwargs={'course_key_string': six.text_type(course_key)})
             certificates_url = ''
-            if configuration_helpers.get_value_for_org(current_organization, "CERTIFICATES_HTML_VIEW", False) and context_course.cert_html_view_enabled:
+            if is_certificates_enabled_for_course_site(course_key) and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
       %>


### PR DESCRIPTION
use is_certificates_enabled_for_course_site for header.html links instead of exclusively reading CERTIFICATES_HTML_VIEW from the SiteConfiguration models.

### Needs other PRs:

 - https://github.com/appsembler/edx-platform/pull/1196
