### PR TITLE
studio: remove publisher link; refactor cert link

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -21,7 +21,6 @@
       <%
             course_key = context_course.id
             url_encoded_course_key = quote(six.text_type(course_key).encode('utf-8'), safe='')
-            current_organization = context_course.org
             index_url = reverse('course_handler', kwargs={'course_key_string': six.text_type(course_key)})
             course_team_url = reverse('course_team_handler', kwargs={'course_key_string': six.text_type(course_key)})
             assets_url = reverse('assets_handler', kwargs={'course_key_string': six.text_type(course_key)})
@@ -35,7 +34,7 @@
             advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
             tabs_url = reverse('tabs_handler', kwargs={'course_key_string': six.text_type(course_key)})
             certificates_url = ''
-            if configuration_helpers.get_value_for_org(current_organization, "CERTIFICATES_HTML_VIEW", False) and context_course.cert_html_view_enabled:
+            if configuration_helpers.get_value_for_org(course_key.org, "CERTIFICATES_HTML_VIEW", False) and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
       %>
@@ -105,11 +104,6 @@
                   % if certificates_url:
                   <li class="nav-item nav-course-settings-certificates">
                     <a href="${certificates_url}">${_("Certificates")}</a>
-                  </li>
-                  % endif
-                  % if frontend_app_publisher_url:
-                  <li class="nav-item nav-course-courseware-videos">
-                    <a href="${frontend_app_publisher_url}/course-runs/${url_encoded_course_key}">${_("Publisher")}</a>
                   </li>
                   % endif
                 </ul>


### PR DESCRIPTION
 - hack: publisher link appears for some reason for tahoe 2.0 sites, removed at
   the html level.
 - simplify cert link to use `course_key.org` instead of another
   variable

minor fixes for RED-3200