### PR TITLE
add linkedin-specific og image sharing properties

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -42,8 +42,10 @@
 %>
 % if (og_image_use_course_images and course):
   <meta name="og:image" content="${course_image_url(course)}" />
+  <meta name="image" property="og:image" content="${course_image_url(course)}" />
 % else:
   <meta name="og:image" content="${default_og_image}" />
+  <meta name="image" property="og:image" content="${default_og_image}" />
 % endif
 
 <%include file="partials/analytics.html" />


### PR DESCRIPTION
## Change description

LinkedIn requires a slightly specific og:image sharing property to choose the right sharing image. Added.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
