### PR TITLE
fix syntax error with else in head-extra

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -77,7 +77,7 @@
 
           gtag('config', '${client_ga_code}');
         </script>
-      % else
+      % else:
         <script>
           ga('create', '${client_ga_code}', 'auto', 'clientTracker');
           ga('clientTracker.send', 'pageview');


### PR DESCRIPTION
```
Fragment 'else' is not a partial control statement in file '/edx/var/edxapp/themes/edx-theme-codebase/customer_specific/lms/templates/head-extra.html' at line: 80 char: 1
```

fixes https://sentry.io/organizations/appsembler/issues/3603956128/?project=145493&query=is%3Aunresolved