### PR TITLE
RED-3691 Fix GTM causing video to not load

### DIFF
--- a/lms/templates/body-extra.html
+++ b/lms/templates/body-extra.html
@@ -51,4 +51,16 @@
     <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/e4awi275';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
   % endif
 
+  <%! from openedx.core.djangolib.js_utils import js_escaped_string %>
+  <%
+  customer_gtm_id = get_global_settings().get('customer_gtm_id')
+  %>
+
+  % if customer_gtm_id:
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${customer_gtm_id | n, js_escaped_string}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  % endif
+
 % endif

--- a/lms/templates/body-initial.html
+++ b/lms/templates/body-initial.html
@@ -1,17 +1,4 @@
-<%namespace file='/theme-variables.html' import="get_global_settings" />
-<%! from openedx.core.djangolib.js_utils import js_escaped_string %>
 <%!
   from hijack.templatetags.hijack_tags import _render_hijack_notification
 %>
 ${_render_hijack_notification((request))}
-
-<%
-customer_gtm_id = get_global_settings().get('customer_gtm_id')
-%>
-
-% if customer_gtm_id:
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${customer_gtm_id | n, js_escaped_string}"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-% endif


### PR DESCRIPTION
## Change description

Unlike other integration scripts, Google Tag Manager is in `body-initial.html` instead of `body-extra.html`. This is to move it to `body-extra.html` because it's causing video loading to fail sometimes. See the upstream discussion regarding the issue [here](https://discuss.openedx.org/t/first-video-on-lesson-dont-work/3836/4)

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fixes: https://appsembler.atlassian.net/browse/RED-3691
Upstream discussion: https://discuss.openedx.org/t/first-video-on-lesson-dont-work/3836/4

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
