### PR TITLE
Add a timeout delay prior to GTM init to fix intermittent YouTube video module loading problems

### DIFF
--- a/lms/templates/partials/analytics.html
+++ b/lms/templates/partials/analytics.html
@@ -60,12 +60,15 @@
         }];
       </script>
     % endif
+    ## Add a timeout delay to GTM initialization to avoid breaking video module loading from YouTube
+    ## with Google Analytics v<4 with Measure Videos turneed on
+    ## see: https://discuss.openedx.org/t/first-video-on-lesson-dont-work/3836/3
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    <script>const loadGTM = function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','${customer_gtm_id | n, js_escaped_string}');</script>
+    };setTimeout(loadGTM.bind(null, window,document,'script','dataLayer','${customer_gtm_id | n, js_escaped_string}'), 1000);</script>
     <!-- End Google Tag Manager -->
   % endif
 


### PR DESCRIPTION
## Change description

Address intermittent failure to load YouTube video module content Apparently only an issue when customer uses Google Analytics<4 with Measure videos turned on Following solution proposed in  https://discuss.openedx.org/t/first-video-on-lesson-dont-work/3836/3B 


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-97

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
