### PR TITLE
Increase timeout before gtm init to 3 seconds for yt video api compat

### DIFF
--- a/lms/templates/partials/analytics.html
+++ b/lms/templates/partials/analytics.html
@@ -68,7 +68,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    };setTimeout(loadGTM.bind(null, window,document,'script','dataLayer','${customer_gtm_id | n, js_escaped_string}'), 1000);</script>
+    };setTimeout(loadGTM.bind(null, window,document,'script','dataLayer','${customer_gtm_id | n, js_escaped_string}'), 3000);</script>
     <!-- End Google Tag Manager -->
   % endif
 


### PR DESCRIPTION
## Change description

Cockroach still saw on and off problems with YouTube video loading because of an issue with GTM initialization even after introducing a 1 second timeout.  Trying to increase timeout to 3 secs.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-97

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
