### PR TITLE
Move all GA and GTM code to end of body tag

### DIFF
--- a/lms/templates/body-extra.html
+++ b/lms/templates/body-extra.html
@@ -2,6 +2,8 @@
 <%! import hmac %>
 <%! import hashlib %>
 
+<%include file="partials/analytics.html" />
+
 ## Renders when Cookie Banner is disabled or when it is enabled and user has dismissed (accepted) it:
 % if (not get_global_settings().get('cookie_notification_enabled', False)) or (get_global_settings().get('cookie_notification_enabled', False) and (request.COOKIES.get('cookieconsent_status', '') == 'dismiss')):
 
@@ -49,18 +51,6 @@
         };
     </script>
     <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/e4awi275';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
-  % endif
-
-  <%! from openedx.core.djangolib.js_utils import js_escaped_string %>
-  <%
-  customer_gtm_id = get_global_settings().get('customer_gtm_id')
-  %>
-
-  % if customer_gtm_id:
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${customer_gtm_id | n, js_escaped_string}"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
   % endif
 
 % endif

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -48,7 +48,6 @@
   <meta name="image" property="og:image" content="${default_og_image}" />
 % endif
 
-<%include file="partials/analytics.html" />
 
 % if get_global_settings().get('default_additional_site_head_content', ''):
   ${get_global_settings().get('default_additional_site_head_content')}
@@ -56,36 +55,6 @@
 
 ## Renders when Cookie Banner is disabled or when it is enabled and user has dismissed (accepted) it:
 % if (not get_global_settings().get('cookie_notification_enabled', False)) or (get_global_settings().get('cookie_notification_enabled', False) and (request.COOKIES.get('cookieconsent_status', '') == 'dismiss')):
-
-  <%
-    appsembler_ga_code = get_global_settings().get('appsembler_ga_code', '');
-    client_ga_code = get_global_settings().get('client_ga_code', '');
-    client_ga_enabled = get_global_settings().get('client_ga_enabled', True);
-    client_ga_version = get_global_settings().get('client_ga_version', 'v3');
-  %>
-  % if SHOW_GOOGLE_ANALYTICS:
-    % if client_ga_code and client_ga_enabled:
-      ## for now Appsembler is still using v3 Universal Analytics and some customers do too.
-      ## once Appsembler and all customers shift to v4 we remove this condition
-      % if client_ga_version == 'v4':
-        <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=${client_ga_code}"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', '${client_ga_code}');
-        </script>
-      % else:
-        <script>
-          ga('create', '${client_ga_code}', 'auto', 'clientTracker');
-          ga('clientTracker.send', 'pageview');
-        </script>
-      % endif
-    % endif
-    <!-- /Google Analytics code -->
-  % endif
 
   % if get_global_settings().get('cookie_accepted_additional_site_head_content', ''):
     % if request.COOKIES.get('cookieconsent_status', '') == 'dismiss':

--- a/lms/templates/partials/analytics.html
+++ b/lms/templates/partials/analytics.html
@@ -97,6 +97,35 @@
       Dimension3: Visited course name
       Dimension4: LMS or Studio
     -->
+    <%
+    appsembler_ga_code = get_global_settings().get('appsembler_ga_code', '');
+    client_ga_code = get_global_settings().get('client_ga_code', '');
+    client_ga_enabled = get_global_settings().get('client_ga_enabled', True);
+    client_ga_version = get_global_settings().get('client_ga_version', 'v3');
+    %>
+
+    % if SHOW_GOOGLE_ANALYTICS:
+    % if client_ga_code and client_ga_enabled:
+      ## for now Appsembler is still using v3 Universal Analytics and some customers do too.
+      ## once Appsembler and all customers shift to v4 we remove this condition
+      % if client_ga_version == 'v4':
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=${client_ga_code}"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${client_ga_code}');
+        </script>
+      % else:
+        <script>
+          ga('create', '${client_ga_code}', 'auto', 'clientTracker');
+          ga('clientTracker.send', 'pageview');
+        </script>
+      % endif
+    % endif
+    <!-- /Google Analytics code -->
+    % endif
 
     <%
       appsemblerLmsTrackingCode = get_global_settings().get('appsembler_lms_tracking_code')
@@ -119,4 +148,11 @@
     <!-- /new analytics -->
   % endif
 
+% endif
+
+% if customer_gtm_id:
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${customer_gtm_id | n, js_escaped_string}"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 % endif

--- a/lms/templates/partials/analytics.html
+++ b/lms/templates/partials/analytics.html
@@ -68,7 +68,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    };setTimeout(loadGTM.bind(null, window,document,'script','dataLayer','${customer_gtm_id | n, js_escaped_string}'), 3000);</script>
+    };setTimeout(loadGTM.bind(null, window,document,'script','dataLayer','${customer_gtm_id | n, js_escaped_string}'), 1000);</script>
     <!-- End Google Tag Manager -->
   % endif
 


### PR DESCRIPTION
## Change description

GTM/GA loading is interfering with the YouTube API.  While Google likes you to put a script tag at the top of `<head>` it is supposed to all work even in body, just means there is a bit more delay in initializing and sending data to Google, and could mean some tracking could get missed if a user bounces off the page before it completes loading.  Given the use case is generallly interested users, it's probably fine.

So the code is moved out of head-extra and added to body-extra.  Seems to be OK, testing on devstack, but it's a little bit hard to get a good real-world use case so I'd like to try it on Tahoe Staging.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-97

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
